### PR TITLE
fix: getAllVaultMetadataLov

### DIFF
--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -740,6 +740,7 @@ export default class CegaEthSDK {
     const { results }: ContractCallResults = await multicall.call(contractCallContext);
 
     const metadatasByVaultAddress = results.vaultMetadataList.callsReturnContext
+      .filter((x) => x.returnValues.length > 0)
       .map((x) => {
         // const productNameLeverageTuple = x.reference.split(nameTypeDelimiter)[0];
         const fcnVaultMetadataArray = multicallProcessReturnContext(x) as FCNVaultMetadata[];

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -696,7 +696,9 @@ export default class CegaEthSDK {
 
     const { results }: ContractCallResults = await multicall.call(contractCallContext);
 
+    // filter out multicalls that return an empty array of vaultMetadatas
     const metadatasByVaultAddress = results.vaultMetadataList.callsReturnContext
+      .filter((x) => x.returnValues.length > 0)
       .map((x) => {
         // const productNameLeverageTuple = x.reference.split(nameTypeDelimiter)[0];
         const fcnVaultMetadataArray = multicallProcessReturnContext(x) as FCNVaultMetadata[];
@@ -739,6 +741,7 @@ export default class CegaEthSDK {
 
     const { results }: ContractCallResults = await multicall.call(contractCallContext);
 
+    // filter out multicalls that return an empty array of vaultMetadatas
     const metadatasByVaultAddress = results.vaultMetadataList.callsReturnContext
       .filter((x) => x.returnValues.length > 0)
       .map((x) => {


### PR DESCRIPTION
No longer throws an error if the product / leverage combination does not exist, instead filters for existing ones first. (Otherwise, the map was throwing an undefined error) 