### PR TITLE
Bump version to 1.0.8 to include getDecimals()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
didn't bump the version for this pr https://github.com/cega-fi/cega-sdk-evm/pull/5