### PR TITLE
Initialize EVM SDK for V2 contract CEG-937 CEG-981 CEG-977 CEG-978 CEG-979 CEG-980 CEG-992 CEG-999

### DIFF
--- a/cp_abis.sh
+++ b/cp_abis.sh
@@ -1,3 +1,4 @@
+# EVM SDK V1
 path_to_cega_eth_v1="../cega-eth-v1/artifacts/contracts"
 
 echo "Creating directories"
@@ -17,3 +18,13 @@ for viewer_abi in "${viewer_abis[@]}"
 do
   cp "${path_to_cega_eth_v1}/viewers/${viewer_abi}.sol/${viewer_abi}.json" ./src/abi/viewers
 done
+
+# EVM SDK V2
+echo "Starting copying ABIs for v2"
+path_to_cega_eth_v2="../cega-eth-v2/artifacts/contracts"
+path_to_abis_v2="./src/abiV2"
+mkdir -p "${path_to_abis_v2}"
+
+cp "${path_to_cega_eth_v2}/cega-strategies/dcs/interfaces/IDCSEntry.sol/IDCSEntry.json" ${path_to_abis_v2}
+
+echo "Completed copying ABIs for v2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   ],
   "scripts": {
     "build": "tsc",
-    "dev": "ts-node ./src/app.ts",
+    "dev": "ts-node ./src/testScripts/sdkV1-getters.ts",
     "prepublishOnly": "npm run build",
-    "start": "node ./dist/app.ts",
+    "start": "node ./dist/testScripts/sdkV1-getters.ts",
     "lint-fix": "npx prettier --write ."
   },
   "dependencies": {

--- a/src/abiV2/IDCSEntry.json
+++ b/src/abiV2/IDCSEntry.json
@@ -1,0 +1,1763 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "IDCSEntry",
+  "sourceName": "contracts/cega-strategies/dcs/interfaces/IDCSEntry.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "auctionWinner",
+          "type": "address"
+        }
+      ],
+      "name": "AuctionWon",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "daysToStartAuctionDefault",
+          "type": "uint8"
+        }
+      ],
+      "name": "DaysToStartAuctionDefaultUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "daysToStartLateFees",
+          "type": "uint8"
+        }
+      ],
+      "name": "DaysToStartLateFeesUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "daysToStartSettlementDefault",
+          "type": "uint8"
+        }
+      ],
+      "name": "DaysToStartSettlementDefaultUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "amount",
+          "type": "uint128"
+        }
+      ],
+      "name": "DepositProcessed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "amount",
+          "type": "uint128"
+        }
+      ],
+      "name": "DepositQueued",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "disputePeriodInHours",
+          "type": "uint8"
+        }
+      ],
+      "name": "DisputePeriodInHoursUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isDepositQueueOpen",
+          "type": "bool"
+        }
+      ],
+      "name": "IsDepositQueueOpenUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "isPayoffInDepositAsset",
+          "type": "bool"
+        }
+      ],
+      "name": "IsPayoffInDepositAssetUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ManagementFeeUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "maxDepositAmountLimit",
+          "type": "uint256"
+        }
+      ],
+      "name": "MaxDepositAmountLimitUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "minDepositAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "MinDepositAmountUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "minWithdrawalAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "MinWithdrawalAmountUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "enum SettlementStatus",
+          "name": "settlementStatus",
+          "type": "uint8"
+        }
+      ],
+      "name": "SettlementStatusUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_tokenSymbol",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "_tokenName",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "_vaultStartDate",
+          "type": "uint256"
+        }
+      ],
+      "name": "VaultCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "enum VaultStatus",
+          "name": "vaultStatus",
+          "type": "uint8"
+        }
+      ],
+      "name": "VaultStatusUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "sharesAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "nextProductId",
+          "type": "uint32"
+        }
+      ],
+      "name": "WithdrawalProcessed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "sharesAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "nextProductId",
+          "type": "uint32"
+        }
+      ],
+      "name": "WithdrawalQueued",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "YieldFeeUpdated",
+      "type": "event"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint128",
+          "name": "amount",
+          "type": "uint128"
+        },
+        {
+          "internalType": "address",
+          "name": "receiver",
+          "type": "address"
+        }
+      ],
+      "name": "addToDCSDepositQueue",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "sharesAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint32",
+          "name": "nextProductId",
+          "type": "uint32"
+        }
+      ],
+      "name": "addToDCSWithdrawalQueue",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkCheckDCSAuctionDefault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkCheckDCSSettlementDefault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkCheckDCSTradesExpiry",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkCollectDCSFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkOpenDCSVaultsDeposits",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxProcessCount",
+          "type": "uint256"
+        }
+      ],
+      "name": "bulkProcessDCSDepositQueues",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxProcessCount",
+          "type": "uint256"
+        }
+      ],
+      "name": "bulkProcessDCSWithdrawalQueues",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkRolloverDCSVaults",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkSettleDCSVaults",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "vaultAddresses",
+          "type": "address[]"
+        }
+      ],
+      "name": "bulkStartDCSTrades",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "calculateDCSLateFee",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "calculateDCSVaultFinalPayoff",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "checkDCSAuctionDefault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "checkDCSSettlementDefault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "checkDCSTradeExpiry",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "collectDCSVaultFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "convertToAssets",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "assets",
+          "type": "uint256"
+        }
+      ],
+      "name": "convertToShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint128",
+              "name": "maxDepositAmountLimit",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint128",
+              "name": "minDepositAmount",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint128",
+              "name": "minWithdrawalAmount",
+              "type": "uint128"
+            },
+            {
+              "internalType": "address",
+              "name": "quoteAssetAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "baseAssetAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "enum DCSOptionType",
+              "name": "dcsOptionType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint8",
+              "name": "daysToStartLateFees",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint8",
+              "name": "daysToStartAuctionDefault",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint8",
+              "name": "daysToStartSettlementDefault",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint16",
+              "name": "lateFeeBps",
+              "type": "uint16"
+            },
+            {
+              "internalType": "uint16",
+              "name": "strikeBarrierBps",
+              "type": "uint16"
+            },
+            {
+              "internalType": "uint40",
+              "name": "tenorInSeconds",
+              "type": "uint40"
+            },
+            {
+              "internalType": "uint8",
+              "name": "disputePeriodInHours",
+              "type": "uint8"
+            }
+          ],
+          "internalType": "struct DCSProductCreationParams",
+          "name": "creationParams",
+          "type": "tuple"
+        }
+      ],
+      "name": "createDCSProduct",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "internalType": "string",
+          "name": "_tokenName",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "_tokenSymbol",
+          "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_vaultStartDate",
+          "type": "uint256"
+        }
+      ],
+      "name": "createDCSVault",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_auctionWinner",
+          "type": "address"
+        },
+        {
+          "internalType": "uint40",
+          "name": "_tradeStartDate",
+          "type": "uint40"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_aprBps",
+          "type": "uint256"
+        },
+        {
+          "internalType": "enum IOracleEntry.DataSource",
+          "name": "dataSource",
+          "type": "uint8"
+        }
+      ],
+      "name": "endDCSAuction",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getDCSCouponPayment",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        }
+      ],
+      "name": "getDCSDepositQueue",
+      "outputs": [
+        {
+          "internalType": "address[]",
+          "name": "depositors",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint128[]",
+          "name": "amounts",
+          "type": "uint128[]"
+        },
+        {
+          "internalType": "uint128",
+          "name": "totalAmount",
+          "type": "uint128"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getDCSLatestProductId",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        }
+      ],
+      "name": "getDCSProduct",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "id",
+              "type": "uint32"
+            },
+            {
+              "internalType": "bool",
+              "name": "isDepositQueueOpen",
+              "type": "bool"
+            },
+            {
+              "internalType": "uint128",
+              "name": "maxDepositAmountLimit",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint128",
+              "name": "minDepositAmount",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint128",
+              "name": "minWithdrawalAmount",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint128",
+              "name": "sumVaultUnderlyingAmounts",
+              "type": "uint128"
+            },
+            {
+              "internalType": "address[]",
+              "name": "vaults",
+              "type": "address[]"
+            },
+            {
+              "internalType": "enum DCSOptionType",
+              "name": "dcsOptionType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "address",
+              "name": "quoteAssetAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "baseAssetAddress",
+              "type": "address"
+            },
+            {
+              "internalType": "uint8",
+              "name": "daysToStartLateFees",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint8",
+              "name": "daysToStartAuctionDefault",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint8",
+              "name": "daysToStartSettlementDefault",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint16",
+              "name": "lateFeeBps",
+              "type": "uint16"
+            },
+            {
+              "internalType": "uint16",
+              "name": "strikeBarrierBps",
+              "type": "uint16"
+            },
+            {
+              "internalType": "uint40",
+              "name": "tenorInSeconds",
+              "type": "uint40"
+            },
+            {
+              "internalType": "uint8",
+              "name": "disputePeriodInHours",
+              "type": "uint8"
+            }
+          ],
+          "internalType": "struct DCSProduct",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        }
+      ],
+      "name": "getDCSProductDepositAsset",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getDCSVault",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "enum SettlementStatus",
+              "name": "settlementStatus",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bool",
+              "name": "isPayoffInDepositAsset",
+              "type": "bool"
+            },
+            {
+              "internalType": "uint256",
+              "name": "aprBps",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "initialSpotPrice",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "strikePrice",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalYield",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct DCSVault",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getDCSWithdrawalQueue",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "internalType": "uint32",
+              "name": "nextProductId",
+              "type": "uint32"
+            }
+          ],
+          "internalType": "struct Withdrawer[]",
+          "name": "withdrawers",
+          "type": "tuple[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "amounts",
+          "type": "uint256[]"
+        },
+        {
+          "internalType": "uint256",
+          "name": "totalAmount",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getDaysLate",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getIsDefaulted",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "timestamp",
+          "type": "uint64"
+        }
+      ],
+      "name": "getOraclePriceOverride",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "getVault",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint32",
+              "name": "productId",
+              "type": "uint32"
+            },
+            {
+              "internalType": "uint256",
+              "name": "yieldFeeBps",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "managementFeeBps",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "vaultStartDate",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint40",
+              "name": "tradeStartDate",
+              "type": "uint40"
+            },
+            {
+              "internalType": "address",
+              "name": "auctionWinner",
+              "type": "address"
+            },
+            {
+              "internalType": "address",
+              "name": "underlyingAsset",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "totalAssets",
+              "type": "uint256"
+            },
+            {
+              "internalType": "enum VaultStatus",
+              "name": "vaultStatus",
+              "type": "uint8"
+            },
+            {
+              "internalType": "uint256",
+              "name": "auctionWinnerTokenId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "enum IOracleEntry.DataSource",
+              "name": "dataSource",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bool",
+              "name": "isInDispute",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct Vault",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vault",
+          "type": "address"
+        }
+      ],
+      "name": "getVaultProductId",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "isDCSWithdrawalPossible",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "openVaultDeposits",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "timestamp",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint256",
+          "name": "newPrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "overrideOraclePrice",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxProcessCount",
+          "type": "uint256"
+        }
+      ],
+      "name": "processDCSDepositQueue",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vault",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "maxProcessCount",
+          "type": "uint256"
+        }
+      ],
+      "name": "processDCSWithdrawalQueue",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "newPrice",
+          "type": "uint256"
+        }
+      ],
+      "name": "processTradeDispute",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "rolloverDCSVault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "isDepositQueueOpen",
+          "type": "bool"
+        },
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        }
+      ],
+      "name": "setDCSIsDepositQueueOpen",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "newState",
+          "type": "bool"
+        }
+      ],
+      "name": "setDCSIsPayoffInDepositAsset",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "setDCSManagementFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "maxDepositAmountLimit",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        }
+      ],
+      "name": "setDCSMaxDepositAmountLimit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "minDepositAmount",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        }
+      ],
+      "name": "setDCSMinDepositAmount",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint128",
+          "name": "minWithdrawalAmount",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        }
+      ],
+      "name": "setDCSMinWithdrawalAmount",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "enum SettlementStatus",
+          "name": "_settlementStatus",
+          "type": "uint8"
+        }
+      ],
+      "name": "setDCSSettlementStatus",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "setDCSYieldFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint8",
+          "name": "daysToStartAuctionDefault",
+          "type": "uint8"
+        }
+      ],
+      "name": "setDaysToStartAuctionDefault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint8",
+          "name": "daysToStartLateFees",
+          "type": "uint8"
+        }
+      ],
+      "name": "setDaysToStartLateFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint8",
+          "name": "daysToStartSettlementDefault",
+          "type": "uint8"
+        }
+      ],
+      "name": "setDaysToStartSettlementDefault",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "productId",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint8",
+          "name": "disputePeriodInHours",
+          "type": "uint8"
+        }
+      ],
+      "name": "setDipsutePeriodInHours",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "enum VaultStatus",
+          "name": "_vaultStatus",
+          "type": "uint8"
+        }
+      ],
+      "name": "setVaultStatus",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "settleDCSVault",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "startDCSTrade",
+      "outputs": [],
+      "stateMutability": "payable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "submitDispute",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "vaultAddress",
+          "type": "address"
+        }
+      ],
+      "name": "totalAssets",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x",
+  "deployedBytecode": "0x",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import CegaEvmSDK from './sdk';
+import CegaEvmSDKV2 from './sdkV2';
 import {
   GasStation,
   EthereumAlchemyGasStation,
@@ -17,4 +18,5 @@ export {
   PolygonGasStation,
   ArbitrumAlchemyGasStation,
   types,
+  CegaEvmSDKV2,
 };

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -1,0 +1,106 @@
+import { ethers } from 'ethers';
+import { EvmAddress, TxOverrides } from './types';
+import { GasStation } from './GasStation';
+
+import Erc20Abi from './abi/ERC20.json';
+import IDCSEntryAbi from './abiV2/IDCSEntry.json';
+
+export default class CegaEvmSDKV2 {
+  private _provider: ethers.providers.Provider;
+
+  private _signer: ethers.Signer | undefined;
+
+  private _gasStation: GasStation;
+
+  private _cegaEntryAddress: EvmAddress;
+
+  constructor(
+    cegaEntryAddress: EvmAddress,
+    gasStation: GasStation,
+    provider: ethers.providers.Provider,
+    signer: ethers.Signer | undefined = undefined,
+  ) {
+    this._provider = provider;
+    this._signer = signer;
+    this._gasStation = gasStation;
+    this._cegaEntryAddress = cegaEntryAddress;
+  }
+
+  setProvider(provider: ethers.providers.Provider) {
+    this._provider = provider;
+  }
+
+  setSigner(signer: ethers.Signer) {
+    this._signer = signer;
+  }
+
+  setCegaEntryAddress(cegaEntryAddress: EvmAddress) {
+    this._cegaEntryAddress = cegaEntryAddress;
+  }
+
+  loadCegaEntry(): ethers.Contract {
+    return new ethers.Contract(
+      this._cegaEntryAddress,
+      IDCSEntryAbi.abi,
+      this._signer || this._provider,
+    );
+  }
+
+  async getProductDcs(productId: ethers.BigNumberish) {
+    const cegaEntry = this.loadCegaEntry();
+    return cegaEntry.getDCSProduct(productId);
+  }
+
+  async setIsDepositQueueOpenDcs(
+    productId: ethers.BigNumberish,
+    isOpen: boolean,
+  ): Promise<ethers.providers.TransactionResponse> {
+    const cegaEntry = this.loadCegaEntry();
+    return cegaEntry.setDCSIsDepositQueueOpen(isOpen, productId);
+  }
+
+  async approveDepositDcs(
+    amount: ethers.BigNumber,
+    asset: EvmAddress,
+    overrides: TxOverrides = {},
+  ): Promise<ethers.providers.TransactionResponse> {
+    if (asset === ethers.constants.AddressZero) {
+      throw new Error('Invalid asset address');
+    }
+
+    const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
+    return erc20Contract.approve(this._cegaEntryAddress, amount, {
+      ...(await this._gasStation.getGasOraclePrices()),
+      ...overrides,
+    });
+  }
+
+  async addToDepositQueueDcs(
+    productId: ethers.BigNumberish,
+    amount: ethers.BigNumber,
+    asset: EvmAddress = ethers.constants.AddressZero,
+    overrides: TxOverrides = {},
+  ): Promise<ethers.providers.TransactionResponse> {
+    if (!this._signer) {
+      throw new Error('Signer not defined');
+    }
+
+    const cegaEntry = this.loadCegaEntry();
+    return cegaEntry.addToDCSDepositQueue(productId, amount, await this._signer.getAddress(), {
+      ...(await this._gasStation.getGasOraclePrices()),
+      ...overrides,
+      value: asset === ethers.constants.AddressZero ? amount : 0,
+    });
+  }
+
+  async bulkOpenVaultDepositsDcs(
+    vaultAddresses: EvmAddress[],
+    overrides: TxOverrides = {},
+  ): Promise<ethers.providers.TransactionResponse> {
+    const cegaEntry = this.loadCegaEntry();
+    return cegaEntry.bulkOpenDCSVaultsDeposits(vaultAddresses, {
+      ...(await this._gasStation.getGasOraclePrices()),
+      ...overrides,
+    });
+  }
+}

--- a/src/testScripts/sdkV1-getters.ts
+++ b/src/testScripts/sdkV1-getters.ts
@@ -10,7 +10,7 @@ import {
   ArbitrumAlchemyGasStation,
   PolygonGasStation,
   types,
-} from '.';
+} from '..';
 
 dotenv.config();
 

--- a/src/testScripts/sdkV2-scripts.ts
+++ b/src/testScripts/sdkV2-scripts.ts
@@ -1,0 +1,79 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as dotenv from 'dotenv';
+
+import { ethers } from 'ethers';
+import { CegaEvmSDKV2, EthereumAlchemyGasStation, types, GasStation } from '..';
+
+dotenv.config();
+
+const config = {
+  ethereum: {
+    RPC_URL: process.env.ETH_RPC_URL,
+    cegaEntryAddress: '' as types.EvmAddress,
+    usdcAddress: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48' as types.EvmAddress,
+    gasStation: new EthereumAlchemyGasStation(process.env.ETH_ALCHEMY_API_KEY || ''),
+  },
+  arbitrum: {
+    RPC_URL: process.env.ARBITRUM_RPC_URL,
+    cegaEntryAddress: '0x10a5524f7c4e2fc62a1106e77cb8a53026bca252' as types.EvmAddress,
+    usdcAddress: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831' as types.EvmAddress,
+    gasStation: new GasStation(),
+  },
+};
+
+const CURRENT_NETWORK = 'arbitrum';
+const { cegaEntryAddress, RPC_URL, gasStation } = config[CURRENT_NETWORK];
+
+const ADMIN_ACCOUNTS = {
+  programAdminPk: process.env.PROGRAM_ADMIN_PK || '',
+  operatorAdminPk: process.env.OPERATOR_ADMIN_PK || '',
+  traderAdminPk: process.env.TRADER_ADMIN_PK || '',
+  serviceAdminPk: process.env.SERVICE_ADMIN_PK || '',
+  userPk: process.env.RANDOM_USER_PK || '',
+};
+
+async function addDeposits() {
+  const provider = new ethers.providers.JsonRpcProvider(RPC_URL);
+  const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.userPk, provider);
+
+  const sdk = new CegaEvmSDKV2(cegaEntryAddress, gasStation, provider, userSigner);
+
+  // const product = await sdk.getProductDcs(2);
+  // const product2 = await sdk.getProductDcs(2);
+  // const product3 = await sdk.getProductDcs(3);
+
+  // open deposit queue
+  // await sdk.setIsDepositQueueOpenDcs(2, true);
+
+  // Deposit Ethereum
+  // const amount = ethers.utils.parseUnits('0.001', 18);
+  // const txResponse = await sdk.addToDepositQueueDcs(2, amount);
+  // console.log('Ethereum Deposit: ', txResponse.hash);
+
+  // open deposit queue
+  await sdk.setIsDepositQueueOpenDcs(1, true);
+  // Deposit ERC20
+  const amountUsdc = ethers.utils.parseUnits('0.1', 6);
+  const approveTx = await sdk.approveDepositDcs(amountUsdc, config.arbitrum.usdcAddress);
+  const approveResponse = await approveTx.wait();
+  console.log('approve USDC: ', approveResponse.transactionHash);
+  const depositTx = await sdk.addToDepositQueueDcs(1, amountUsdc, config.arbitrum.usdcAddress);
+  console.log('deposit USDC: ', depositTx.hash);
+}
+
+async function bulkActions() {
+  const provider = new ethers.providers.JsonRpcProvider(RPC_URL);
+  const traderSigner = new ethers.Wallet(ADMIN_ACCOUNTS.traderAdminPk, provider);
+
+  const sdk = new CegaEvmSDKV2(cegaEntryAddress, gasStation, provider, traderSigner);
+
+  // Bulk Open Vault Deposits
+  await sdk.bulkOpenVaultDepositsDcs([]);
+}
+
+async function main() {
+  await addDeposits();
+  // await bulkActions();
+}
+
+main();

--- a/src/testScripts/testCache.ts
+++ b/src/testScripts/testCache.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import * as dotenv from 'dotenv';
-import CegaEvmSDK from './sdk';
-import { GasStation } from './GasStation';
+import CegaEvmSDK from '../sdk';
+import { GasStation } from '../GasStation';
 
 dotenv.config();
 


### PR DESCRIPTION
Initialize a new EVM SDK class to interact with CegaEntry of the new V2 contract.

Can use these examples to write future function implementations.

CEG-937
CEG-981
CEG-977
CEG-978
CEG-979
CEG-980
CEG-992
CEG-999