### PR TITLE
CEG-1129 sdkV2: use increaseAllowance instead of approve

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -90,37 +90,41 @@ export default class CegaEvmSDKV2 {
    * USER FACING METHODS
    */
 
-  async approveErc20(amount: ethers.BigNumber, asset: EvmAddress, overrides: TxOverrides = {}) {
+  async increaseAllowanceErc20(
+    amount: ethers.BigNumber,
+    asset: EvmAddress,
+    overrides: TxOverrides = {},
+  ) {
     if (asset === ethers.constants.AddressZero) {
       throw new Error('Invalid asset address');
     }
 
     const chainConfig = await this.getChainConfig();
     if (chainConfig.name === 'ethereum-mainnet' && asset === chainConfig.tokens.stETH) {
-      return this.approveErc20ForCegaProxy(amount, asset, overrides);
+      return this.increaseAllowanceErc20ForCegaProxy(amount, asset, overrides);
     }
-    return this.approveErc20ForCegaEntry(amount, asset, overrides);
+    return this.increaseAllowanceErc20ForCegaEntry(amount, asset, overrides);
   }
 
-  private async approveErc20ForCegaEntry(
+  private async increaseAllowanceErc20ForCegaEntry(
     amount: ethers.BigNumber,
     asset: EvmAddress,
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    return erc20Contract.approve(this._cegaEntryAddress, amount, {
+    return erc20Contract.increaseAllowance(this._cegaEntryAddress, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
       ...overrides,
     });
   }
 
-  private async approveErc20ForCegaProxy(
+  private async increaseAllowanceErc20ForCegaProxy(
     amount: ethers.BigNumber,
     asset: EvmAddress,
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    return erc20Contract.approve(this._cegaWrappingProxyAddress, amount, {
+    return erc20Contract.increaseAllowance(this._cegaWrappingProxyAddress, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
       ...overrides,
     });

--- a/src/testScripts/sdkV2-scripts.ts
+++ b/src/testScripts/sdkV2-scripts.ts
@@ -74,9 +74,9 @@ async function addDeposits(network: 'ethereum' | 'arbitrum') {
   const usdcProductId = 2;
   // await sdk.dcsSetIsDepositQueueOpen(usdcProductId, true);
   amount = ethers.utils.parseUnits('0.1', 6);
-  txResponse = await sdk.approveErc20(amount, config.usdcAddress);
+  txResponse = await sdk.increaseAllowanceErc20(amount, config.usdcAddress);
   txReceipt = await txResponse.wait();
-  console.log('approve USDC: ', txReceipt.transactionHash);
+  console.log('increaseAllowance USDC: ', txReceipt.transactionHash);
   txResponse = await sdk.dcsAddToDepositQueue(usdcProductId, amount, config.usdcAddress);
   console.log('deposit USDC: ', txResponse.hash);
 
@@ -84,9 +84,9 @@ async function addDeposits(network: 'ethereum' | 'arbitrum') {
   const stethProductId = 3; // wrapped steth actually
   // await sdk.dcsSetIsDepositQueueOpen(stethProductId, true);
   amount = ethers.utils.parseUnits('0.00005', 18);
-  txResponse = await sdk.approveErc20(amount, config.stEth);
+  txResponse = await sdk.increaseAllowanceErc20(amount, config.stEth);
   txReceipt = await txResponse.wait();
-  console.log('approve stETH: ', txReceipt.transactionHash);
+  console.log('increaseAllowance stETH: ', txReceipt.transactionHash);
   txResponse = await sdk.dcsAddToDepositQueue(stethProductId, amount, config.stEth);
   console.log('deposit stETH: ', txResponse.hash);
 }


### PR DESCRIPTION
metamask (and maybe gnosis) works cleaner with increaseAllowance instead of the approve. doesn't require the user to re-type the amount they want to deposit into the contract