### PR TITLE
Fixed bad entry call for oracle price override

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -383,9 +383,9 @@ export default class CegaEvmSDKV2 {
     vaultAddress: EvmAddress,
     overrideDateTime: Date,
   ): Promise<ethers.BigNumber> {
-    const oracleEntry = await this.loadOracleEntry();
+    const cegaEntry = await this.loadCegaEntry();
     const overrideDateInSeconds = Math.floor(overrideDateTime.getTime() / 1000);
-    return oracleEntry.getOraclePriceOverride(vaultAddress, overrideDateInSeconds);
+    return cegaEntry.getOraclePriceOverride(vaultAddress, overrideDateInSeconds);
   }
 
   /**


### PR DESCRIPTION
## Changes
- Oracle entry doesnt have `getOraclePriceOverride`, should be cega Entry
<img width="556" alt="image" src="https://github.com/cega-fi/cega-sdk-evm/assets/11513667/bfdfb7d5-24a2-4e97-a3c7-a27f7df2f16c">
