### PR TITLE
withdrawStuckAssets: revert back to no receiver argument

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -253,19 +253,17 @@ export default class CegaEvmSDKV2 {
    * for native ETH underlying vaults, for non EOA wallet (eg. multisigs)
    *
    * @param asset - The address of asset to be withdrawn
-   * @param receiver - The address of the wallet to receive funds
    * @returns Transaction response
    */
   async withdrawStuckAssets(
     asset: EvmAddress,
-    receiver: EvmAddress | null = null,
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
-    if (receiver === null && this._signer === undefined) {
+    if (!this._signer) {
       throw new Error('Signer not defined');
     }
     const treasury = await this.loadTreasury();
-    return treasury.withdrawStuckAssets(asset, receiver || (await this._signer?.getAddress()), {
+    return treasury.withdrawStuckAssets(asset, await this._signer.getAddress(), {
       ...(await this._gasStation.getGasOraclePrices()),
       ...overrides,
     });


### PR DESCRIPTION
I'm concerned that we might accidentally pass in a receiver argument when we really shouldn't in most cases in our app

Let's abstract that option away from the SDK caller for now, as that is the default for most of the time. If there's a specific use case that require it, we can bring it back in the future