### PR TITLE
loadPythAdapter: need to check the address when loading not in caller

### DIFF
--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -107,6 +107,9 @@ export default class CegaEvmSDKV2 {
   }
 
   async loadPythAdapter(): Promise<ethers.Contract> {
+    if (!this._pythAdapterAddress) {
+      throw new Error('PythAdapterAddress not defined');
+    }
     return new ethers.Contract(
       this._pythAdapterAddress,
       PythAdapterAbi.abi,
@@ -529,9 +532,6 @@ export default class CegaEvmSDKV2 {
     updates: string[],
     fee: BigNumberish,
   ): Promise<ethers.providers.TransactionResponse> {
-    if (!this._pythAdapterAddress) {
-      throw new Error('PythAdapterAddress not defined');
-    }
     const pythAdapter = await this.loadPythAdapter();
     return pythAdapter.updateAssetPrices(
       Math.floor(timestamp.getTime() / 1000),


### PR DESCRIPTION
caller shouldn't need to check the pyth address. the pythLoader should check the pyth address so it's shared across all