### PR TITLE
[CEG-1530] Dynamic gas limit with manual gas limit as a fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",
@@ -22,7 +22,7 @@
   "scripts": {
     "build": "tsc",
     "dev-sdkV1": "ts-node ./src/testScripts/sdkV1-getters.ts",
-    "dev-sdkV2": "ts-node ./src/testScripts/sdkV1-scripts.ts",
+    "dev-sdkV2": "ts-node ./src/testScripts/sdkV2-scripts.ts",
     "prepublishOnly": "npm run build",
     "start": "node ./dist/testScripts/sdkV1-getters.ts",
     "lint-fix": "npx prettier --write ."

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -23,7 +23,7 @@ import {
 } from './types';
 
 import {
-  getEstimatedGasLimitWithOverrides,
+  getOverridesWithEstimatedGasLimit,
   getEvmContractType,
   productNameLeverageTuple,
   splitArrayIntoChunks,
@@ -241,7 +241,7 @@ export default class CegaEvmSDK {
 
     return cegaState.addOracle(oracleName, oracleAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaState,
         'addOracle',
         [oracleName, oracleAddress],
@@ -259,7 +259,7 @@ export default class CegaEvmSDK {
 
     return cegaState.removeOracle(oracleName, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaState,
         'removeOracle',
         [oracleName],
@@ -278,7 +278,7 @@ export default class CegaEvmSDK {
 
     return oracle.addNextRoundData(nextRoundData, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         oracle,
         'addNextRoundData',
         [nextRoundData],
@@ -298,7 +298,7 @@ export default class CegaEvmSDK {
 
     return oracle.updateRoundData(roundId, roundData, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         oracle,
         'updateRoundData',
         [roundId, roundData],
@@ -345,7 +345,7 @@ export default class CegaEvmSDK {
 
     return cegaState.updateMarketMakerPermission(marketMakerAddress, allow, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaState,
         'updateMarketMakerPermission',
         [marketMakerAddress, allow],
@@ -373,7 +373,7 @@ export default class CegaEvmSDK {
 
     return cegaState.setFeeRecipient(feeRecipient, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaState,
         'setFeeRecipient',
         [feeRecipient],
@@ -393,7 +393,7 @@ export default class CegaEvmSDK {
 
     return cegaState.moveAssetsToProduct(productName, vaultAddress, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaState,
         'moveAssetsToProduct',
         [productName, vaultAddress, amount],
@@ -416,7 +416,7 @@ export default class CegaEvmSDK {
 
     return cegaState.addProduct(productName, productAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaState,
         'addProduct',
         [productName, productAddress],
@@ -434,7 +434,7 @@ export default class CegaEvmSDK {
 
     return cegaState.removeProduct(productName, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaState,
         'removeProduct',
         [productName],
@@ -1085,7 +1085,7 @@ export default class CegaEvmSDK {
 
     return product.setManagementFeeBps(managementFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setManagementFeeBps',
         [managementFeeBps],
@@ -1110,7 +1110,7 @@ export default class CegaEvmSDK {
 
     return product.setYieldFeeBps(yieldFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setYieldFeeBps',
         [yieldFeeBps],
@@ -1135,7 +1135,7 @@ export default class CegaEvmSDK {
 
     return product.setIsDepositQueueOpen(isDepositQueueOpen, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setIsDepositQueueOpen',
         [isDepositQueueOpen],
@@ -1155,7 +1155,7 @@ export default class CegaEvmSDK {
 
     return product.setIsDepositQueueOpen(leverage, isDepositQueueOpen, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setIsDepositQueueOpen',
         [leverage, isDepositQueueOpen],
@@ -1181,7 +1181,7 @@ export default class CegaEvmSDK {
 
     return product.setMaxDepositAmountLimit(maxDepositAmountLimit, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setMaxDepositAmountLimit',
         [maxDepositAmountLimit],
@@ -1201,7 +1201,7 @@ export default class CegaEvmSDK {
 
     return product.setMaxDepositAmountLimit(leverage, maxDepositAmountLimit, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setMaxDepositAmountLimit',
         [leverage, maxDepositAmountLimit],
@@ -1224,7 +1224,7 @@ export default class CegaEvmSDK {
 
     return product.createVault(tokenName, tokenSymbol, vaultStartInSeconds, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'createVault',
         [tokenName, tokenSymbol, vaultStartInSeconds],
@@ -1247,7 +1247,7 @@ export default class CegaEvmSDK {
 
     return product.createVault(tokenName, tokenSymbol, vaultStartInSeconds, leverage, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'createVault',
         [tokenName, tokenSymbol, vaultStartInSeconds, leverage],
@@ -1271,7 +1271,7 @@ export default class CegaEvmSDK {
     }
     return product.removeVault(vaultIndex, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'removeVault',
         [vaultIndex],
@@ -1296,7 +1296,7 @@ export default class CegaEvmSDK {
 
     return product.removeVault(leverage, vaultIndex, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'removeVault',
         [leverage, vaultIndex],
@@ -1325,7 +1325,7 @@ export default class CegaEvmSDK {
       tenorInDays,
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           product,
           'setTradeData',
           [
@@ -1352,7 +1352,7 @@ export default class CegaEvmSDK {
 
     return product.addOptionBarrier(vaultAddress, optionBarrier, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'addOptionBarrier',
         [vaultAddress, optionBarrier],
@@ -1381,7 +1381,7 @@ export default class CegaEvmSDK {
       barrierAbsoluteValue,
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           product,
           'updateOptionBarrier',
           [vaultAddress, index, asset, strikeAbsoluteValue, barrierAbsoluteValue],
@@ -1404,7 +1404,7 @@ export default class CegaEvmSDK {
 
     return product.updateOptionBarrierOracle(vaultAddress, index, asset, newOracleName, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'updateOptionBarrierOracle',
         [vaultAddress, index, asset, newOracleName],
@@ -1425,7 +1425,7 @@ export default class CegaEvmSDK {
 
     return product.removeOptionBarrier(vaultAddress, index, asset, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'removeOptionBarrier',
         [vaultAddress, index, asset],
@@ -1445,7 +1445,7 @@ export default class CegaEvmSDK {
 
     return product.setVaultStatus(vaultAddress, vaultStatus, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setVaultStatus',
         [vaultAddress, vaultStatus],
@@ -1464,7 +1464,7 @@ export default class CegaEvmSDK {
 
     return product.openVaultDeposits(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'openVaultDeposits',
         [vaultAddress],
@@ -1484,7 +1484,7 @@ export default class CegaEvmSDK {
 
     return product.setKnockInStatus(vaultAddress, newState, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'setKnockInStatus',
         [vaultAddress, newState],
@@ -1520,7 +1520,7 @@ export default class CegaEvmSDK {
 
     return erc20Contract.approve(product.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         erc20Contract,
         'approve',
         [product.address, amount],
@@ -1543,7 +1543,7 @@ export default class CegaEvmSDK {
 
     return erc20Contract.increaseAllowance(product.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         erc20Contract,
         'increaseAllowance',
         [product.address, amount],
@@ -1563,7 +1563,7 @@ export default class CegaEvmSDK {
 
     return product.addToDepositQueue(amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'addToDepositQueue',
         [amount],
@@ -1583,7 +1583,7 @@ export default class CegaEvmSDK {
 
     return product.addToDepositQueue(leverage, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'addToDepositQueue',
         [leverage, amount],
@@ -1603,7 +1603,7 @@ export default class CegaEvmSDK {
 
     return product.processDepositQueue(vaultAddress, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'processDepositQueue',
         [vaultAddress, maxProcessCount],
@@ -1639,7 +1639,7 @@ export default class CegaEvmSDK {
 
     return vault.approve(product.address, amountShares, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         vault,
         'approve',
         [product.address, amountShares],
@@ -1661,7 +1661,7 @@ export default class CegaEvmSDK {
 
     return vault.increaseAllowance(product.address, amountShares, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         vault,
         'increaseAllowance',
         [product.address, amountShares],
@@ -1681,7 +1681,7 @@ export default class CegaEvmSDK {
 
     return product.addToWithdrawalQueue(vaultAddress, amountShares, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'addToWithdrawalQueue',
         [vaultAddress, amountShares],
@@ -1700,7 +1700,7 @@ export default class CegaEvmSDK {
 
     return product.collectFees(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'collectFees',
         [vaultAddress],
@@ -1720,7 +1720,7 @@ export default class CegaEvmSDK {
 
     return product.processWithdrawalQueue(vaultAddress, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'processWithdrawalQueue',
         [vaultAddress, maxProcessCount],
@@ -1739,7 +1739,7 @@ export default class CegaEvmSDK {
 
     return product.rolloverVault(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'rolloverVault',
         [vaultAddress],
@@ -1760,7 +1760,7 @@ export default class CegaEvmSDK {
 
     return product.sendAssetsToTrade(vaultAddress, receiver, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'sendAssetsToTrade',
         [vaultAddress, receiver, amount],
@@ -1782,7 +1782,7 @@ export default class CegaEvmSDK {
 
     return product.checkBarriers(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'checkBarriers',
         [vaultAddress],
@@ -1801,7 +1801,7 @@ export default class CegaEvmSDK {
 
     return product.calculateCurrentYield(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'calculateCurrentYield',
         [vaultAddress],
@@ -1820,7 +1820,7 @@ export default class CegaEvmSDK {
 
     return product.calculateVaultFinalPayoff(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         product,
         'calculateVaultFinalPayoff',
         [vaultAddress],
@@ -1838,7 +1838,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkCalculateCurrentYield(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkCalculateCurrentYield',
         [vaultAddresses],
@@ -1856,7 +1856,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkCalculateVaultFinalPayoffs(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkCalculateVaultFinalPayoffs',
         [vaultAddresses],
@@ -1874,7 +1874,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkCheckBarriers(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkCheckBarriers',
         [vaultAddresses],
@@ -1896,7 +1896,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkOpenVaultDeposits(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkOpenVaultDeposits',
         [vaultAddresses],
@@ -1917,7 +1917,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkProcessDepositQueues(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkProcessDepositQueues',
         [params],
@@ -1946,7 +1946,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkSetTradeData(accumulatedParams, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkSetTradeData',
         [accumulatedParams],
@@ -1970,7 +1970,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkUpdateOptionBarriers(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkUpdateOptionBarriers',
         [params],
@@ -1992,7 +1992,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkSendAssetsToTrade(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkSendAssetsToTrade',
         [params],
@@ -2014,7 +2014,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkMoveAssetsToProducts(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkMoveAssetsToProducts',
         [params],
@@ -2032,7 +2032,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkCollectFees(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkCollectFees',
         [vaultAddresses],
@@ -2053,7 +2053,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkProcessWithdrawalQueues(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkProcessWithdrawalQueues',
         [params],
@@ -2071,7 +2071,7 @@ export default class CegaEvmSDK {
 
     return bulkActionsEntry.bulkRolloverVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         bulkActionsEntry,
         'bulkRolloverVaults',
         [vaultAddresses],

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -23,7 +23,7 @@ import {
 } from './types';
 
 import {
-  getEstimatedGasLimit,
+  getEstimatedGasLimitWithOverrides,
   getEvmContractType,
   productNameLeverageTuple,
   splitArrayIntoChunks,
@@ -238,16 +238,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaState = await this.loadCegaStateContract();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaState,
-      'addOracle',
-      [oracleName, oracleAddress],
-      this._signer,
-    );
+
     return cegaState.addOracle(oracleName, oracleAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaState,
+        'addOracle',
+        [oracleName, oracleAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -256,16 +256,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaState = await this.loadCegaStateContract();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaState,
-      'removeOracle',
-      [oracleName],
-      this._signer,
-    );
+
     return cegaState.removeOracle(oracleName, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaState,
+        'removeOracle',
+        [oracleName],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -275,16 +275,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const oracle = await this.loadOracleContract(oracleName);
-    const gasLimit = await getEstimatedGasLimit(
-      oracle,
-      'addNextRoundData',
-      [nextRoundData],
-      this._signer,
-    );
+
     return oracle.addNextRoundData(nextRoundData, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        oracle,
+        'addNextRoundData',
+        [nextRoundData],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -295,16 +295,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const oracle = await this.loadOracleContract(oracleName);
-    const gasLimit = await getEstimatedGasLimit(
-      oracle,
-      'updateRoundData',
-      [roundId, roundData],
-      this._signer,
-    );
+
     return oracle.updateRoundData(roundId, roundData, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        oracle,
+        'updateRoundData',
+        [roundId, roundData],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -342,16 +342,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaState = await this.loadCegaStateContract();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaState,
-      'updateMarketMakerPermission',
-      [marketMakerAddress, allow],
-      this._signer,
-    );
+
     return cegaState.updateMarketMakerPermission(marketMakerAddress, allow, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaState,
+        'updateMarketMakerPermission',
+        [marketMakerAddress, allow],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -370,16 +370,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaState = await this.loadCegaStateContract();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaState,
-      'setFeeRecipient',
-      [feeRecipient],
-      this._signer,
-    );
+
     return cegaState.setFeeRecipient(feeRecipient, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaState,
+        'setFeeRecipient',
+        [feeRecipient],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -390,16 +390,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ) {
     const cegaState = await this.loadCegaStateContract();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaState,
-      'moveAssetsToProduct',
-      [productName, vaultAddress, amount],
-      this._signer,
-    );
+
     return cegaState.moveAssetsToProduct(productName, vaultAddress, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaState,
+        'moveAssetsToProduct',
+        [productName, vaultAddress, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -413,16 +413,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaState = await this.loadCegaStateContract();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaState,
-      'addProduct',
-      [productName, productAddress],
-      this._signer,
-    );
+
     return cegaState.addProduct(productName, productAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaState,
+        'addProduct',
+        [productName, productAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -431,16 +431,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaState = await this.loadCegaStateContract();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaState,
-      'removeProduct',
-      [productName],
-      this._signer,
-    );
+
     return cegaState.removeProduct(productName, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaState,
+        'removeProduct',
+        [productName],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1082,16 +1082,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setManagementFeeBps',
-      [managementFeeBps],
-      this._signer,
-    );
+
     return product.setManagementFeeBps(managementFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setManagementFeeBps',
+        [managementFeeBps],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1107,16 +1107,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setYieldFeeBps',
-      [yieldFeeBps],
-      this._signer,
-    );
+
     return product.setYieldFeeBps(yieldFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setYieldFeeBps',
+        [yieldFeeBps],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1132,16 +1132,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setIsDepositQueueOpen',
-      [isDepositQueueOpen],
-      this._signer,
-    );
+
     return product.setIsDepositQueueOpen(isDepositQueueOpen, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setIsDepositQueueOpen',
+        [isDepositQueueOpen],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1152,16 +1152,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setIsDepositQueueOpen',
-      [leverage, isDepositQueueOpen],
-      this._signer,
-    );
+
     return product.setIsDepositQueueOpen(leverage, isDepositQueueOpen, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setIsDepositQueueOpen',
+        [leverage, isDepositQueueOpen],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1178,16 +1178,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setMaxDepositAmountLimit',
-      [maxDepositAmountLimit],
-      this._signer,
-    );
+
     return product.setMaxDepositAmountLimit(maxDepositAmountLimit, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setMaxDepositAmountLimit',
+        [maxDepositAmountLimit],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1198,16 +1198,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setMaxDepositAmountLimit',
-      [leverage, maxDepositAmountLimit],
-      this._signer,
-    );
+
     return product.setMaxDepositAmountLimit(leverage, maxDepositAmountLimit, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setMaxDepositAmountLimit',
+        [leverage, maxDepositAmountLimit],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1221,16 +1221,16 @@ export default class CegaEvmSDK {
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
     const vaultStartInSeconds = Math.floor(vaultStart.getTime() / 1000);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'createVault',
-      [tokenName, tokenSymbol, vaultStartInSeconds],
-      this._signer,
-    );
+
     return product.createVault(tokenName, tokenSymbol, vaultStartInSeconds, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'createVault',
+        [tokenName, tokenSymbol, vaultStartInSeconds],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1244,16 +1244,16 @@ export default class CegaEvmSDK {
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
     const vaultStartInSeconds = Math.floor(vaultStart.getTime() / 1000);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'createVault',
-      [tokenName, tokenSymbol, vaultStartInSeconds, leverage],
-      this._signer,
-    );
+
     return product.createVault(tokenName, tokenSymbol, vaultStartInSeconds, leverage, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'createVault',
+        [tokenName, tokenSymbol, vaultStartInSeconds, leverage],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1269,11 +1269,15 @@ export default class CegaEvmSDK {
     if (vaultIndex === -1) {
       throw new Error('Vault address not found');
     }
-    const gasLimit = await getEstimatedGasLimit(product, 'removeVault', [vaultIndex], this._signer);
     return product.removeVault(vaultIndex, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'removeVault',
+        [vaultIndex],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1289,16 +1293,16 @@ export default class CegaEvmSDK {
     if (vaultIndex === -1) {
       throw new Error('Vault address not found');
     }
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'removeVault',
-      [leverage, vaultIndex],
-      this._signer,
-    );
+
     return product.removeVault(leverage, vaultIndex, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'removeVault',
+        [leverage, vaultIndex],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1312,18 +1316,7 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setTradeData',
-      [
-        vaultAddress,
-        Math.floor(tradeDate.getTime() / 1000),
-        Math.floor(tradeExpiry.getTime() / 1000),
-        aprBps,
-        tenorInDays,
-      ],
-      this._signer,
-    );
+
     return product.setTradeData(
       vaultAddress,
       Math.floor(tradeDate.getTime() / 1000),
@@ -1332,8 +1325,19 @@ export default class CegaEvmSDK {
       tenorInDays,
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          product,
+          'setTradeData',
+          [
+            vaultAddress,
+            Math.floor(tradeDate.getTime() / 1000),
+            Math.floor(tradeExpiry.getTime() / 1000),
+            aprBps,
+            tenorInDays,
+          ],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -1345,16 +1349,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'addOptionBarrier',
-      [vaultAddress, optionBarrier],
-      this._signer,
-    );
+
     return product.addOptionBarrier(vaultAddress, optionBarrier, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'addOptionBarrier',
+        [vaultAddress, optionBarrier],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1368,12 +1372,7 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'updateOptionBarrier',
-      [vaultAddress, index, asset, strikeAbsoluteValue, barrierAbsoluteValue],
-      this._signer,
-    );
+
     return product.updateOptionBarrier(
       vaultAddress,
       index,
@@ -1382,8 +1381,13 @@ export default class CegaEvmSDK {
       barrierAbsoluteValue,
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          product,
+          'updateOptionBarrier',
+          [vaultAddress, index, asset, strikeAbsoluteValue, barrierAbsoluteValue],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -1397,16 +1401,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'updateOptionBarrierOracle',
-      [vaultAddress, index, asset, newOracleName],
-      this._signer,
-    );
+
     return product.updateOptionBarrierOracle(vaultAddress, index, asset, newOracleName, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'updateOptionBarrierOracle',
+        [vaultAddress, index, asset, newOracleName],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1418,16 +1422,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'removeOptionBarrier',
-      [vaultAddress, index, asset],
-      this._signer,
-    );
+
     return product.removeOptionBarrier(vaultAddress, index, asset, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'removeOptionBarrier',
+        [vaultAddress, index, asset],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1438,16 +1442,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setVaultStatus',
-      [vaultAddress, vaultStatus],
-      this._signer,
-    );
+
     return product.setVaultStatus(vaultAddress, vaultStatus, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setVaultStatus',
+        [vaultAddress, vaultStatus],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1457,16 +1461,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'openVaultDeposits',
-      [vaultAddress],
-      this._signer,
-    );
+
     return product.openVaultDeposits(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'openVaultDeposits',
+        [vaultAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1477,16 +1481,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'setKnockInStatus',
-      [vaultAddress, newState],
-      this._signer,
-    );
+
     return product.setKnockInStatus(vaultAddress, newState, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'setKnockInStatus',
+        [vaultAddress, newState],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1513,16 +1517,16 @@ export default class CegaEvmSDK {
     const product = await this.loadProductContract(productName);
     const asset: EvmAddress = await product.asset();
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    const gasLimit = await getEstimatedGasLimit(
-      erc20Contract,
-      'approve',
-      [product.address, amount],
-      this._signer,
-    );
+
     return erc20Contract.approve(product.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        erc20Contract,
+        'approve',
+        [product.address, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1536,16 +1540,16 @@ export default class CegaEvmSDK {
     const product = await this.loadProductContract(productName);
     const asset: EvmAddress = await product.asset();
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    const gasLimit = await getEstimatedGasLimit(
-      erc20Contract,
-      'increaseAllowance',
-      [product.address, amount],
-      this._signer,
-    );
+
     return erc20Contract.increaseAllowance(product.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        erc20Contract,
+        'increaseAllowance',
+        [product.address, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1556,16 +1560,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'addToDepositQueue',
-      [amount],
-      this._signer,
-    );
+
     return product.addToDepositQueue(amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'addToDepositQueue',
+        [amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1576,16 +1580,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'addToDepositQueue',
-      [leverage, amount],
-      this._signer,
-    );
+
     return product.addToDepositQueue(leverage, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'addToDepositQueue',
+        [leverage, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1596,16 +1600,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'processDepositQueue',
-      [vaultAddress, maxProcessCount],
-      this._signer,
-    );
+
     return product.processDepositQueue(vaultAddress, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'processDepositQueue',
+        [vaultAddress, maxProcessCount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1632,16 +1636,16 @@ export default class CegaEvmSDK {
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
     const vault = await this.loadVaultContract(vaultAddress);
-    const gasLimit = await getEstimatedGasLimit(
-      vault,
-      'approve',
-      [product.address, amountShares],
-      this._signer,
-    );
+
     return vault.approve(product.address, amountShares, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        vault,
+        'approve',
+        [product.address, amountShares],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1654,16 +1658,16 @@ export default class CegaEvmSDK {
     // NOTE: not all ERC20 tokens have `increaseAllowance` function
     const product = await this.loadProductContract(productName);
     const vault = await this.loadVaultContract(vaultAddress);
-    const gasLimit = await getEstimatedGasLimit(
-      vault,
-      'increaseAllowance',
-      [product.address, amountShares],
-      this._signer,
-    );
+
     return vault.increaseAllowance(product.address, amountShares, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        vault,
+        'increaseAllowance',
+        [product.address, amountShares],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1674,16 +1678,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'addToWithdrawalQueue',
-      [vaultAddress, amountShares],
-      this._signer,
-    );
+
     return product.addToWithdrawalQueue(vaultAddress, amountShares, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'addToWithdrawalQueue',
+        [vaultAddress, amountShares],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1693,16 +1697,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'collectFees',
-      [vaultAddress],
-      this._signer,
-    );
+
     return product.collectFees(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'collectFees',
+        [vaultAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1713,16 +1717,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'processWithdrawalQueue',
-      [vaultAddress, maxProcessCount],
-      this._signer,
-    );
+
     return product.processWithdrawalQueue(vaultAddress, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'processWithdrawalQueue',
+        [vaultAddress, maxProcessCount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1732,16 +1736,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'rolloverVault',
-      [vaultAddress],
-      this._signer,
-    );
+
     return product.rolloverVault(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'rolloverVault',
+        [vaultAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1753,16 +1757,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'sendAssetsToTrade',
-      [vaultAddress, receiver, amount],
-      this._signer,
-    );
+
     return product.sendAssetsToTrade(vaultAddress, receiver, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'sendAssetsToTrade',
+        [vaultAddress, receiver, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1775,16 +1779,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'checkBarriers',
-      [vaultAddress],
-      this._signer,
-    );
+
     return product.checkBarriers(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'checkBarriers',
+        [vaultAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1794,16 +1798,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'calculateCurrentYield',
-      [vaultAddress],
-      this._signer,
-    );
+
     return product.calculateCurrentYield(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'calculateCurrentYield',
+        [vaultAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1813,16 +1817,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const product = await this.loadProductContract(productName);
-    const gasLimit = await getEstimatedGasLimit(
-      product,
-      'calculateVaultFinalPayoff',
-      [vaultAddress],
-      this._signer,
-    );
+
     return product.calculateVaultFinalPayoff(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        product,
+        'calculateVaultFinalPayoff',
+        [vaultAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1831,16 +1835,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkCalculateCurrentYield',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkCalculateCurrentYield(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkCalculateCurrentYield',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1849,16 +1853,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkCalculateVaultFinalPayoffs',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkCalculateVaultFinalPayoffs(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkCalculateVaultFinalPayoffs',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1867,16 +1871,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkCheckBarriers',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkCheckBarriers(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkCheckBarriers',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1889,16 +1893,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkOpenVaultDeposits',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkOpenVaultDeposits(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkOpenVaultDeposits',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1910,16 +1914,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkProcessDepositQueues',
-      [params],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkProcessDepositQueues(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkProcessDepositQueues',
+        [params],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1939,16 +1943,16 @@ export default class CegaEvmSDK {
       tradeDate: Math.floor(param.tradeDate.getTime() / 1000),
       tradeExpiry: Math.floor(param.tradeExpiry.getTime() / 1000),
     }));
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkSetTradeData',
-      [accumulatedParams],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkSetTradeData(accumulatedParams, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkSetTradeData',
+        [accumulatedParams],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1963,16 +1967,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkUpdateOptionBarriers',
-      [params],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkUpdateOptionBarriers(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkUpdateOptionBarriers',
+        [params],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1985,16 +1989,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkSendAssetsToTrade',
-      [params],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkSendAssetsToTrade(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkSendAssetsToTrade',
+        [params],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -2007,16 +2011,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkMoveAssetsToProducts',
-      [params],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkMoveAssetsToProducts(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkMoveAssetsToProducts',
+        [params],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -2025,16 +2029,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkCollectFees',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkCollectFees(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkCollectFees',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -2046,16 +2050,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkProcessWithdrawalQueues',
-      [params],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkProcessWithdrawalQueues(params, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkProcessWithdrawalQueues',
+        [params],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -2064,16 +2068,16 @@ export default class CegaEvmSDK {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const bulkActionsEntry = await this.loadBulkActionsEntryContract();
-    const gasLimit = await getEstimatedGasLimit(
-      bulkActionsEntry,
-      'bulkRolloverVaults',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return bulkActionsEntry.bulkRolloverVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        bulkActionsEntry,
+        'bulkRolloverVaults',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 }

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -521,22 +521,26 @@ export default class CegaEvmSDKV2 {
 
     const chainConfig = await this.getChainConfig();
     if (chainConfig.name === 'ethereum-mainnet' && asset === chainConfig.tokens.stETH) {
+      console.log('addToDepositQueueProxy');
       return this.addToDepositQueueProxy(productId, amount, overrides);
     }
 
     const cegaEntry = await this.loadCegaEntry();
+    console.log('override: ', overrides);
     const gasLimit = await getEstimatedGasLimit(
       cegaEntry,
       'addToDepositQueue',
-      [productId, amount],
+      [productId, amount, await this._signer.getAddress()],
       this._signer,
     );
-    return cegaEntry.addToDepositQueue(productId, amount, await this._signer.getAddress(), {
-      ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
-      value: asset === ethers.constants.AddressZero ? amount : 0,
-    });
+    console.log({ gasLimit });
+    return {} as ethers.providers.TransactionResponse;
+    // return cegaEntry.addToDepositQueue(productId, amount, await this._signer.getAddress(), {
+    //   ...(await this._gasStation.getGasOraclePrices()),
+    //   gasLimit,
+    //   ...overrides,
+    //   value: asset === ethers.constants.AddressZero ? amount : 0,
+    // });
   }
 
   /**

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -10,7 +10,7 @@ import IWrappingProxyAbi from './abiV2/IWrappingProxy.json';
 import OracleEntryAbi from './abiV2/OracleEntry.json';
 import PythAdapterAbi from './abiV2/PythAdapter.json';
 import Chains, { IChainConfig, isValidChain } from './config/chains';
-import { getEstimatedGasLimit } from './utils';
+import { getEstimatedGasLimitWithOverrides } from './utils';
 
 export default class CegaEvmSDKV2 {
   private _provider: ethers.providers.Provider;
@@ -171,16 +171,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'setProductName',
-      [productId, name],
-      this._signer,
-    );
+
     return cegaEntry.setProductName(productId, name, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'setProductName',
+        [productId, name],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -190,16 +190,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'setTradeWinnerNftImage',
-      [productId, imageUrl],
-      this._signer,
-    );
+
     return cegaEntry.setTradeWinnerNftImage(productId, imageUrl, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'setTradeWinnerNftImage',
+        [productId, imageUrl],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -209,16 +209,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'setManagementFee',
-      [vaultAddress, managementFeeBps],
-      this._signer,
-    );
+
     return cegaEntry.setManagementFee(vaultAddress, managementFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'setManagementFee',
+        [vaultAddress, managementFeeBps],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -228,16 +228,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'setYieldFee',
-      [vaultAddress, yieldFeeBps],
-      this._signer,
-    );
+
     return cegaEntry.setYieldFee(vaultAddress, yieldFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'setYieldFee',
+        [vaultAddress, yieldFeeBps],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -309,16 +309,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetBondAllowList',
-      [receiver, isAllowed],
-      this._signer,
-    );
+
     return cegaEntry.fcnSetBondAllowList(receiver, isAllowed, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetBondAllowList',
+        [receiver, isAllowed],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -428,16 +428,16 @@ export default class CegaEvmSDKV2 {
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    const gasLimit = await getEstimatedGasLimit(
-      erc20Contract,
-      'approve',
-      [cegaEntry.address, amount],
-      this._signer,
-    );
+
     return erc20Contract.approve(cegaEntry.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        erc20Contract,
+        'approve',
+        [cegaEntry.address, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -448,16 +448,16 @@ export default class CegaEvmSDKV2 {
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaWrappingProxy = await this.loadCegaWrappingProxy();
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    const gasLimit = await getEstimatedGasLimit(
-      erc20Contract,
-      'approve',
-      [cegaWrappingProxy.address, amount],
-      this._signer,
-    );
+
     return erc20Contract.approve(cegaWrappingProxy.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        erc20Contract,
+        'approve',
+        [cegaWrappingProxy.address, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -472,16 +472,16 @@ export default class CegaEvmSDKV2 {
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    const gasLimit = await getEstimatedGasLimit(
-      erc20Contract,
-      'increaseAllowance',
-      [cegaEntry.address, amount],
-      this._signer,
-    );
+
     return erc20Contract.increaseAllowance(cegaEntry.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        erc20Contract,
+        'increaseAllowance',
+        [cegaEntry.address, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -496,16 +496,16 @@ export default class CegaEvmSDKV2 {
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaWrappingProxy = await this.loadCegaWrappingProxy();
     const erc20Contract = new ethers.Contract(asset, Erc20Abi.abi, this._signer);
-    const gasLimit = await getEstimatedGasLimit(
-      erc20Contract,
-      'increaseAllowance',
-      [cegaWrappingProxy.address, amount],
-      this._signer,
-    );
+
     return erc20Contract.increaseAllowance(cegaWrappingProxy.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        erc20Contract,
+        'increaseAllowance',
+        [cegaWrappingProxy.address, amount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -525,17 +525,15 @@ export default class CegaEvmSDKV2 {
     }
 
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'addToDepositQueue',
-      [productId, amount, await this._signer.getAddress()],
-      this._signer,
-    );
-    console.log({ gasLimit });
+
     return cegaEntry.addToDepositQueue(productId, amount, await this._signer.getAddress(), {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'addToDepositQueue',
+        [productId, amount, await this._signer.getAddress()],
+        this._signer,
+      )),
       value: asset === ethers.constants.AddressZero ? amount : 0,
     });
   }
@@ -559,16 +557,17 @@ export default class CegaEvmSDKV2 {
     }
 
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsAddToDepositQueue',
-      [productId, amount],
-      this._signer,
-    );
-    return cegaEntry.dcsAddToDepositQueue(productId, amount, await this._signer.getAddress(), {
+    const address = await this._signer.getAddress();
+
+    return cegaEntry.dcsAddToDepositQueue(productId, amount, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsAddToDepositQueue',
+        [productId, amount, address],
+        this._signer,
+        overrides,
+      )),
       value: asset === ethers.constants.AddressZero ? amount : 0,
     });
   }
@@ -582,16 +581,16 @@ export default class CegaEvmSDKV2 {
       throw new Error('Signer not defined');
     }
     const proxyEntry = await this.loadCegaWrappingProxy();
-    const gasLimit = await getEstimatedGasLimit(
-      proxyEntry,
-      'wrapAndAddToDepositQueue',
-      [productId, amount, await this._signer.getAddress()],
-      this._signer,
-    );
-    return proxyEntry.wrapAndAddToDepositQueue(productId, amount, await this._signer.getAddress(), {
+    const address = await this._signer.getAddress();
+    return proxyEntry.wrapAndAddToDepositQueue(productId, amount, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        proxyEntry,
+        'wrapAndAddToDepositQueue',
+        [productId, amount, address],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -607,22 +606,17 @@ export default class CegaEvmSDKV2 {
       throw new Error('Signer not defined');
     }
     const proxyEntry = await this.loadCegaWrappingProxy();
-    const gasLimit = await getEstimatedGasLimit(
-      proxyEntry,
-      'wrapAndAddToDCSDepositQueue',
-      [productId, amount, await this._signer.getAddress()],
-      this._signer,
-    );
-    return proxyEntry.wrapAndAddToDCSDepositQueue(
-      productId,
-      amount,
-      await this._signer.getAddress(),
-      {
-        ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
-      },
-    );
+    const address = await this._signer.getAddress();
+    return proxyEntry.wrapAndAddToDCSDepositQueue(productId, amount, address, {
+      ...(await this._gasStation.getGasOraclePrices()),
+      ...(await getEstimatedGasLimitWithOverrides(
+        proxyEntry,
+        'wrapAndAddToDCSDepositQueue',
+        [productId, amount, address],
+        this._signer,
+        overrides,
+      )),
+    });
   }
 
   async addToWithdrawalQueue(
@@ -637,16 +631,16 @@ export default class CegaEvmSDKV2 {
     }
 
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'addToWithdrawalQueue',
-      [vaultAddress, sharesAmount, nextProductId],
-      this._signer,
-    );
+
     return cegaEntry.addToWithdrawalQueue(vaultAddress, sharesAmount, nextProductId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'addToWithdrawalQueue',
+        [vaultAddress, sharesAmount, nextProductId],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -660,22 +654,18 @@ export default class CegaEvmSDKV2 {
     }
 
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'addToWithdrawalQueueWithProxy',
-      [vaultAddress, sharesAmount, await this._signer.getAddress()],
-      this._signer,
-    );
-    return cegaEntry.addToWithdrawalQueueWithProxy(
-      vaultAddress,
-      sharesAmount,
-      await this._signer.getAddress(),
-      {
-        ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
-      },
-    );
+    const address = await this._signer.getAddress();
+
+    return cegaEntry.addToWithdrawalQueueWithProxy(vaultAddress, sharesAmount, address, {
+      ...(await this._gasStation.getGasOraclePrices()),
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'addToWithdrawalQueueWithProxy',
+        [vaultAddress, sharesAmount, address],
+        this._signer,
+        overrides,
+      )),
+    });
   }
 
   /**
@@ -693,16 +683,16 @@ export default class CegaEvmSDKV2 {
     }
 
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsAddToWithdrawalQueue',
-      [vaultAddress, sharesAmount, nextProductId],
-      this._signer,
-    );
+
     return cegaEntry.dcsAddToWithdrawalQueue(vaultAddress, sharesAmount, nextProductId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsAddToWithdrawalQueue',
+        [vaultAddress, sharesAmount, nextProductId],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -719,22 +709,18 @@ export default class CegaEvmSDKV2 {
     }
 
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsAddToWithdrawalQueueWithProxy',
-      [vaultAddress, sharesAmount, await this._signer.getAddress()],
-      this._signer,
-    );
-    return cegaEntry.dcsAddToWithdrawalQueueWithProxy(
-      vaultAddress,
-      sharesAmount,
-      await this._signer.getAddress(),
-      {
-        ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
-      },
-    );
+    const address = await this._signer.getAddress();
+
+    return cegaEntry.dcsAddToWithdrawalQueueWithProxy(vaultAddress, sharesAmount, address, {
+      ...(await this._gasStation.getGasOraclePrices()),
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsAddToWithdrawalQueueWithProxy',
+        [vaultAddress, sharesAmount, address],
+        this._signer,
+        overrides,
+      )),
+    });
   }
 
   /**
@@ -754,15 +740,16 @@ export default class CegaEvmSDKV2 {
     }
     const treasury = await this.loadTreasury();
     const address = await this._signer.getAddress();
-    const gasLimit = await getEstimatedGasLimit(
-      treasury,
-      'withdrawStuckAssets',
-      [asset, address],
-      this._signer,
-    );
+
     return treasury.withdrawStuckAssets(asset, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        treasury,
+        'withdrawStuckAssets',
+        [asset, address],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -781,18 +768,17 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetIsDepositQueueOpen',
-      [isDepositQueueOpen, productId],
-      this._signer,
-    );
 
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetIsDepositQueueOpen(isDepositQueueOpen, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetIsDepositQueueOpen',
+        [isDepositQueueOpen, productId],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -802,17 +788,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetIsDepositQueueOpen',
-      [productId, isDepositQueueOpen],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetIsDepositQueueOpen(productId, isDepositQueueOpen, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetIsDepositQueueOpen',
+        [productId, isDepositQueueOpen],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -821,16 +806,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'bulkOpenVaultDeposits',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.bulkOpenVaultDeposits(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'bulkOpenVaultDeposits',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -840,16 +825,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkProcessDepositQueues',
-      [vaultAddresses, maxProcessCount],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkProcessDepositQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkProcessDepositQueues',
+        [vaultAddresses, maxProcessCount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -859,16 +844,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkProcessDepositQueues',
-      [vaultAddresses, maxProcessCount],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkProcessDepositQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkProcessDepositQueues',
+        [vaultAddresses, maxProcessCount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -884,12 +869,6 @@ export default class CegaEvmSDKV2 {
     const tradesStartInSeconds = tradeStartDates.map((tradeStartDate) =>
       Math.floor(tradeStartDate.getTime() / 1000),
     );
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkEndAuctions',
-      [vaultAddresses, auctionWinners, tradesStartInSeconds, aprBpsList, oracleDataSources],
-      this._signer,
-    );
 
     return cegaEntry.dcsBulkEndAuctions(
       vaultAddresses,
@@ -898,8 +877,13 @@ export default class CegaEvmSDKV2 {
       aprBpsList,
       oracleDataSources,
       {
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          cegaEntry,
+          'dcsBulkEndAuctions',
+          [vaultAddresses, auctionWinners, tradesStartInSeconds, aprBpsList, oracleDataSources],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -916,12 +900,6 @@ export default class CegaEvmSDKV2 {
     const tradesStartInSeconds = tradeStartDates.map((tradeStartDate) =>
       Math.floor(tradeStartDate.getTime() / 1000),
     );
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkEndAuctions',
-      [vaultAddresses, auctionWinners, tradesStartInSeconds, aprBpsList, oracleDataSources],
-      this._signer,
-    );
 
     return cegaEntry.fcnBulkEndAuctions(
       vaultAddresses,
@@ -930,8 +908,13 @@ export default class CegaEvmSDKV2 {
       aprBpsList,
       oracleDataSources,
       {
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          cegaEntry,
+          'fcnBulkEndAuctions',
+          [vaultAddresses, auctionWinners, tradesStartInSeconds, aprBpsList, oracleDataSources],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -946,12 +929,6 @@ export default class CegaEvmSDKV2 {
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
     const tradeStartInSeconds = Math.floor(tradeStartDate.getTime() / 1000);
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsEndAuction',
-      [vaultAddress, auctionWinner, tradeStartInSeconds, aprBps, oracleDataSource],
-      this._signer,
-    );
 
     return cegaEntry.dcsEndAuction(
       vaultAddress,
@@ -960,8 +937,13 @@ export default class CegaEvmSDKV2 {
       aprBps,
       oracleDataSource,
       {
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          cegaEntry,
+          'dcsEndAuction',
+          [vaultAddress, auctionWinner, tradeStartInSeconds, aprBps, oracleDataSource],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -976,12 +958,6 @@ export default class CegaEvmSDKV2 {
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
     const tradeStartInSeconds = Math.floor(tradeStartDate.getTime() / 1000);
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnEndAuction',
-      [vaultAddress, auctionWinner, tradeStartInSeconds, aprBps, oracleDataSources],
-      this._signer,
-    );
 
     return cegaEntry.fcnEndAuction(
       vaultAddress,
@@ -990,8 +966,13 @@ export default class CegaEvmSDKV2 {
       aprBps,
       oracleDataSources,
       {
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          cegaEntry,
+          'fcnEndAuction',
+          [vaultAddress, auctionWinner, tradeStartInSeconds, aprBps, oracleDataSources],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -1006,16 +987,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkStartTrades',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkStartTrades(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkStartTrades',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
       value: nativeAssetTransferSummedAmount ?? 0,
     });
   }
@@ -1026,15 +1007,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkStartTrades',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkStartTrades(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkStartTrades',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
       ...overrides,
       value: nativeAssetTransferSummedAmount ?? 0,
     });
@@ -1046,16 +1028,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkSettleVaults',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkSettleVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkSettleVaults',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
       value: nativeAssetTransferSummedAmount ?? 0,
     });
   }
@@ -1066,16 +1048,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkSettleVaults',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkSettleVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkSettleVaults',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
       value: nativeAssetTransferSummedAmount ?? 0,
     });
   }
@@ -1087,16 +1069,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkRepayBonds',
-      [vaultAddresses, amounts],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkRepayBonds(vaultAddresses, amounts, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkRepayBonds',
+        [vaultAddresses, amounts],
+        this._signer,
+        overrides,
+      )),
       value: nativeAssetTransferSummedAmount ?? 0,
     });
   }
@@ -1110,16 +1092,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkCollectFees',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkCollectFees(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkCollectFees',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1128,16 +1110,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkCollectFees',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkCollectFees(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkCollectFees',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1147,16 +1129,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkProcessWithdrawalQueues',
-      [vaultAddresses, maxProcessCount],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkProcessWithdrawalQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkProcessWithdrawalQueues',
+        [vaultAddresses, maxProcessCount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1166,16 +1148,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkProcessWithdrawalQueues',
-      [vaultAddresses, maxProcessCount],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkProcessWithdrawalQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkProcessWithdrawalQueues',
+        [vaultAddresses, maxProcessCount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1184,16 +1166,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkRolloverVaults',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkRolloverVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkRolloverVaults',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1202,16 +1184,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkRolloverVaults',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkRolloverVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkRolloverVaults',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1224,16 +1206,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSubmitDispute',
-      [vaultAddress],
-      this._signer,
-    );
+
     return cegaEntry.dcsSubmitDispute(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSubmitDispute',
+        [vaultAddress],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1244,17 +1226,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSubmitDispute',
-      [vaultAddress, barrierIndex, Math.floor(overrideDateTime.getTime() / 1000)],
-      this._signer,
-    );
     const overrideDateInSeconds = Math.floor(overrideDateTime.getTime() / 1000);
     return cegaEntry.fcnSubmitDispute(vaultAddress, barrierIndex, overrideDateInSeconds, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSubmitDispute',
+        [vaultAddress, barrierIndex, overrideDateInSeconds],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1264,16 +1245,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsProcessTradeDispute',
-      [vaultAddress, newPrice],
-      this._signer,
-    );
+
     return cegaEntry.dcsProcessTradeDispute(vaultAddress, newPrice, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsProcessTradeDispute',
+        [vaultAddress, newPrice],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1286,12 +1267,7 @@ export default class CegaEvmSDKV2 {
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
     const overrideDateInSeconds = Math.floor(overrideDateTime.getTime() / 1000);
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnProcessTradeDispute',
-      [vaultAddress, barrierIndex, overrideDateInSeconds, newPrice],
-      this._signer,
-    );
+
     return cegaEntry.fcnProcessTradeDispute(
       vaultAddress,
       barrierIndex,
@@ -1299,8 +1275,13 @@ export default class CegaEvmSDKV2 {
       newPrice,
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          cegaEntry,
+          'fcnProcessTradeDispute',
+          [vaultAddress, barrierIndex, overrideDateInSeconds, newPrice],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -1339,12 +1320,7 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsCreateVault',
-      [productId, tokenName, tokenSymbol, yieldFeeBps, managementFeeBps],
-      this._signer,
-    );
+
     return cegaEntry.dcsCreateVault(
       productId,
       {
@@ -1355,8 +1331,13 @@ export default class CegaEvmSDKV2 {
       },
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          cegaEntry,
+          'dcsCreateVault',
+          [productId, { tokenName, tokenSymbol, yieldFeeBps, managementFeeBps }],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -1370,12 +1351,7 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnCreateVault',
-      [productId, tokenName, tokenSymbol, yieldFeeBps, managementFeeBps],
-      this._signer,
-    );
+
     return cegaEntry.fcnCreateVault(
       productId,
       {
@@ -1386,8 +1362,13 @@ export default class CegaEvmSDKV2 {
       },
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        gasLimit,
-        ...overrides,
+        ...(await getEstimatedGasLimitWithOverrides(
+          cegaEntry,
+          'fcnCreateVault',
+          [productId, { tokenName, tokenSymbol, yieldFeeBps, managementFeeBps }],
+          this._signer,
+          overrides,
+        )),
       },
     );
   }
@@ -1398,18 +1379,17 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetMaxUnderlyingAmount',
-      [maxUnderlyingAmount, productId],
-      this._signer,
-    );
 
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetMaxUnderlyingAmount(maxUnderlyingAmount, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetMaxUnderlyingAmount',
+        [maxUnderlyingAmount, productId],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1419,17 +1399,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetMaxUnderlyingAmount',
-      [productId, maxUnderlyingAmount],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetMaxUnderlyingAmount(productId, maxUnderlyingAmount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetMaxUnderlyingAmount',
+        [productId, maxUnderlyingAmount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1439,18 +1418,17 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetMinDepositAmount',
-      [minDepositAmount, productId],
-      this._signer,
-    );
 
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetMinDepositAmount(minDepositAmount, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetMinDepositAmount',
+        [minDepositAmount, productId],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1460,17 +1438,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetMinDepositAmount',
-      [productId, minDepositAmount],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetMinDepositAmount(productId, minDepositAmount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetMinDepositAmount',
+        [productId, minDepositAmount],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1480,17 +1457,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetDaysToStartLateFees',
-      [daysToStartLateFees, productId],
-      this._signer,
-    );
 
     return cegaEntry.dcsSetDaysToStartLateFees(productId, daysToStartLateFees, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetDaysToStartLateFees',
+        [productId, daysToStartLateFees],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1500,18 +1476,17 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetLateFeeBps',
-      [lateFeeBps, productId],
-      this._signer,
-    );
 
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetLateFeeBps(lateFeeBps, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetLateFeeBps',
+        [lateFeeBps, productId],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1521,17 +1496,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetLateFeeBps',
-      [productId, lateFeeBps],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetLateFeeBps(productId, lateFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetLateFeeBps',
+        [productId, lateFeeBps],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1541,17 +1515,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetDaysToStartAuctionDefault',
-      [daysToStartAuctionDefault, productId],
-      this._signer,
-    );
 
     return cegaEntry.dcsSetDaysToStartAuctionDefault(productId, daysToStartAuctionDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetDaysToStartAuctionDefault',
+        [productId, daysToStartAuctionDefault],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1561,17 +1534,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetDaysToStartAuctionDefault',
-      [productId, daysToStartAuctionDefault],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetDaysToStartAuctionDefault(productId, daysToStartAuctionDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetDaysToStartAuctionDefault',
+        [productId, daysToStartAuctionDefault],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1581,17 +1553,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetDaysToStartSettlementDefault',
-      [daysToStartSettlementDefault, productId],
-      this._signer,
-    );
 
     return cegaEntry.dcsSetDaysToStartSettlementDefault(productId, daysToStartSettlementDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetDaysToStartSettlementDefault',
+        [productId, daysToStartSettlementDefault],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1601,17 +1572,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetDaysToStartSettlementDefault',
-      [productId, daysToStartSettlementDefault],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetDaysToStartSettlementDefault(productId, daysToStartSettlementDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetDaysToStartSettlementDefault',
+        [productId, daysToStartSettlementDefault],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1621,17 +1591,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetDisputeGraceDelayInHours',
-      [disputeGraceDelayInHours, productId],
-      this._signer,
-    );
 
     return cegaEntry.dcsSetDisputeGraceDelayInHours(productId, disputeGraceDelayInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetDisputeGraceDelayInHours',
+        [productId, disputeGraceDelayInHours],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1641,17 +1610,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetDisputeGraceDelayInHours',
-      [productId, disputeGraceDelayInHours],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetDisputeGraceDelayInHours(productId, disputeGraceDelayInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetDisputeGraceDelayInHours',
+        [productId, disputeGraceDelayInHours],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1661,17 +1629,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsSetDisputePeriodInHours',
-      [disputePeriodInHours, productId],
-      this._signer,
-    );
 
     return cegaEntry.dcsSetDisputePeriodInHours(productId, disputePeriodInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsSetDisputePeriodInHours',
+        [productId, disputePeriodInHours],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1681,17 +1648,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnSetDisputePeriodInHours',
-      [productId, disputePeriodInHours],
-      this._signer,
-    );
 
     return cegaEntry.fcnSetDisputePeriodInHours(productId, disputePeriodInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnSetDisputePeriodInHours',
+        [productId, disputePeriodInHours],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1705,16 +1671,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkCheckBarriers',
-      [vaultAddresses, maxObservations],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkCheckBarriers(vaultAddresses, maxObservations, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkCheckBarriers',
+        [vaultAddresses, maxObservations],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1723,16 +1689,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkCheckAuctionDefault',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkCheckAuctionDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkCheckAuctionDefault',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1741,16 +1707,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkCheckAuctionDefault',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkCheckAuctionDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkCheckAuctionDefault',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1759,16 +1725,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkCheckSettlementDefault',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkCheckSettlementDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkCheckSettlementDefault',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1777,16 +1743,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkCheckSettlementDefault',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkCheckSettlementDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkCheckSettlementDefault',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1795,16 +1761,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'dcsBulkCheckTradesExpiry',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.dcsBulkCheckTradesExpiry(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'dcsBulkCheckTradesExpiry',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1813,16 +1779,16 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
-    const gasLimit = await getEstimatedGasLimit(
-      cegaEntry,
-      'fcnBulkCheckTradesExpiry',
-      [vaultAddresses],
-      this._signer,
-    );
+
     return cegaEntry.fcnBulkCheckTradesExpiry(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      gasLimit,
-      ...overrides,
+      ...(await getEstimatedGasLimitWithOverrides(
+        cegaEntry,
+        'fcnBulkCheckTradesExpiry',
+        [vaultAddresses],
+        this._signer,
+        overrides,
+      )),
     });
   }
 
@@ -1857,17 +1823,22 @@ export default class CegaEvmSDKV2 {
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const pythAdapter = await this.loadPythAdapter();
-    const gasLimit = await getEstimatedGasLimit(
-      pythAdapter,
-      'updateAssetPrices',
-      [Math.floor(timestamp.getTime() / 1000), assetAddresses, updates],
-      this._signer,
-    );
+
     return pythAdapter.updateAssetPrices(
       Math.floor(timestamp.getTime() / 1000),
       assetAddresses,
       updates,
-      { value: fee, ...(await this._gasStation.getGasOraclePrices()), gasLimit, ...overrides },
+      {
+        value: fee,
+        ...(await this._gasStation.getGasOraclePrices()),
+        ...(await getEstimatedGasLimitWithOverrides(
+          pythAdapter,
+          'updateAssetPrices',
+          [Math.floor(timestamp.getTime() / 1000), assetAddresses, updates],
+          this._signer,
+          overrides,
+        )),
+      },
     );
   }
 }

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -533,6 +533,7 @@ export default class CegaEvmSDKV2 {
         'addToDepositQueue',
         [productId, amount, await this._signer.getAddress()],
         this._signer,
+        overrides,
       )),
       value: asset === ethers.constants.AddressZero ? amount : 0,
     });
@@ -1017,7 +1018,6 @@ export default class CegaEvmSDKV2 {
         this._signer,
         overrides,
       )),
-      ...overrides,
       value: nativeAssetTransferSummedAmount ?? 0,
     });
   }

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -521,12 +521,10 @@ export default class CegaEvmSDKV2 {
 
     const chainConfig = await this.getChainConfig();
     if (chainConfig.name === 'ethereum-mainnet' && asset === chainConfig.tokens.stETH) {
-      console.log('addToDepositQueueProxy');
       return this.addToDepositQueueProxy(productId, amount, overrides);
     }
 
     const cegaEntry = await this.loadCegaEntry();
-    console.log('override: ', overrides);
     const gasLimit = await getEstimatedGasLimit(
       cegaEntry,
       'addToDepositQueue',
@@ -534,13 +532,12 @@ export default class CegaEvmSDKV2 {
       this._signer,
     );
     console.log({ gasLimit });
-    return {} as ethers.providers.TransactionResponse;
-    // return cegaEntry.addToDepositQueue(productId, amount, await this._signer.getAddress(), {
-    //   ...(await this._gasStation.getGasOraclePrices()),
-    //   gasLimit,
-    //   ...overrides,
-    //   value: asset === ethers.constants.AddressZero ? amount : 0,
-    // });
+    return cegaEntry.addToDepositQueue(productId, amount, await this._signer.getAddress(), {
+      ...(await this._gasStation.getGasOraclePrices()),
+      gasLimit,
+      ...overrides,
+      value: asset === ethers.constants.AddressZero ? amount : 0,
+    });
   }
 
   /**

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -10,7 +10,7 @@ import IWrappingProxyAbi from './abiV2/IWrappingProxy.json';
 import OracleEntryAbi from './abiV2/OracleEntry.json';
 import PythAdapterAbi from './abiV2/PythAdapter.json';
 import Chains, { IChainConfig, isValidChain } from './config/chains';
-import { getEstimatedGasLimitWithOverrides } from './utils';
+import { getOverridesWithEstimatedGasLimit } from './utils';
 
 export default class CegaEvmSDKV2 {
   private _provider: ethers.providers.Provider;
@@ -174,7 +174,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.setProductName(productId, name, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'setProductName',
         [productId, name],
@@ -193,7 +193,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.setTradeWinnerNftImage(productId, imageUrl, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'setTradeWinnerNftImage',
         [productId, imageUrl],
@@ -212,7 +212,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.setManagementFee(vaultAddress, managementFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'setManagementFee',
         [vaultAddress, managementFeeBps],
@@ -231,7 +231,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.setYieldFee(vaultAddress, yieldFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'setYieldFee',
         [vaultAddress, yieldFeeBps],
@@ -312,7 +312,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetBondAllowList(receiver, isAllowed, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetBondAllowList',
         [receiver, isAllowed],
@@ -431,7 +431,7 @@ export default class CegaEvmSDKV2 {
 
     return erc20Contract.approve(cegaEntry.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         erc20Contract,
         'approve',
         [cegaEntry.address, amount],
@@ -451,7 +451,7 @@ export default class CegaEvmSDKV2 {
 
     return erc20Contract.approve(cegaWrappingProxy.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         erc20Contract,
         'approve',
         [cegaWrappingProxy.address, amount],
@@ -475,7 +475,7 @@ export default class CegaEvmSDKV2 {
 
     return erc20Contract.increaseAllowance(cegaEntry.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         erc20Contract,
         'increaseAllowance',
         [cegaEntry.address, amount],
@@ -499,7 +499,7 @@ export default class CegaEvmSDKV2 {
 
     return erc20Contract.increaseAllowance(cegaWrappingProxy.address, amount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         erc20Contract,
         'increaseAllowance',
         [cegaWrappingProxy.address, amount],
@@ -528,7 +528,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.addToDepositQueue(productId, amount, await this._signer.getAddress(), {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'addToDepositQueue',
         [productId, amount, await this._signer.getAddress()],
@@ -561,7 +561,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsAddToDepositQueue(productId, amount, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsAddToDepositQueue',
         [productId, amount, address],
@@ -584,7 +584,7 @@ export default class CegaEvmSDKV2 {
     const address = await this._signer.getAddress();
     return proxyEntry.wrapAndAddToDepositQueue(productId, amount, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         proxyEntry,
         'wrapAndAddToDepositQueue',
         [productId, amount, address],
@@ -609,7 +609,7 @@ export default class CegaEvmSDKV2 {
     const address = await this._signer.getAddress();
     return proxyEntry.wrapAndAddToDCSDepositQueue(productId, amount, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         proxyEntry,
         'wrapAndAddToDCSDepositQueue',
         [productId, amount, address],
@@ -634,7 +634,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.addToWithdrawalQueue(vaultAddress, sharesAmount, nextProductId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'addToWithdrawalQueue',
         [vaultAddress, sharesAmount, nextProductId],
@@ -658,7 +658,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.addToWithdrawalQueueWithProxy(vaultAddress, sharesAmount, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'addToWithdrawalQueueWithProxy',
         [vaultAddress, sharesAmount, address],
@@ -686,7 +686,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsAddToWithdrawalQueue(vaultAddress, sharesAmount, nextProductId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsAddToWithdrawalQueue',
         [vaultAddress, sharesAmount, nextProductId],
@@ -713,7 +713,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsAddToWithdrawalQueueWithProxy(vaultAddress, sharesAmount, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsAddToWithdrawalQueueWithProxy',
         [vaultAddress, sharesAmount, address],
@@ -743,7 +743,7 @@ export default class CegaEvmSDKV2 {
 
     return treasury.withdrawStuckAssets(asset, address, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         treasury,
         'withdrawStuckAssets',
         [asset, address],
@@ -772,7 +772,7 @@ export default class CegaEvmSDKV2 {
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetIsDepositQueueOpen(isDepositQueueOpen, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetIsDepositQueueOpen',
         [isDepositQueueOpen, productId],
@@ -791,7 +791,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetIsDepositQueueOpen(productId, isDepositQueueOpen, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetIsDepositQueueOpen',
         [productId, isDepositQueueOpen],
@@ -809,7 +809,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.bulkOpenVaultDeposits(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'bulkOpenVaultDeposits',
         [vaultAddresses],
@@ -828,7 +828,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkProcessDepositQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkProcessDepositQueues',
         [vaultAddresses, maxProcessCount],
@@ -847,7 +847,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkProcessDepositQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkProcessDepositQueues',
         [vaultAddresses, maxProcessCount],
@@ -877,7 +877,7 @@ export default class CegaEvmSDKV2 {
       aprBpsList,
       oracleDataSources,
       {
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           cegaEntry,
           'dcsBulkEndAuctions',
           [vaultAddresses, auctionWinners, tradesStartInSeconds, aprBpsList, oracleDataSources],
@@ -908,7 +908,7 @@ export default class CegaEvmSDKV2 {
       aprBpsList,
       oracleDataSources,
       {
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           cegaEntry,
           'fcnBulkEndAuctions',
           [vaultAddresses, auctionWinners, tradesStartInSeconds, aprBpsList, oracleDataSources],
@@ -937,7 +937,7 @@ export default class CegaEvmSDKV2 {
       aprBps,
       oracleDataSource,
       {
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           cegaEntry,
           'dcsEndAuction',
           [vaultAddress, auctionWinner, tradeStartInSeconds, aprBps, oracleDataSource],
@@ -966,7 +966,7 @@ export default class CegaEvmSDKV2 {
       aprBps,
       oracleDataSources,
       {
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           cegaEntry,
           'fcnEndAuction',
           [vaultAddress, auctionWinner, tradeStartInSeconds, aprBps, oracleDataSources],
@@ -990,7 +990,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkStartTrades(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkStartTrades',
         [vaultAddresses],
@@ -1010,7 +1010,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkStartTrades(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkStartTrades',
         [vaultAddresses],
@@ -1031,7 +1031,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkSettleVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkSettleVaults',
         [vaultAddresses],
@@ -1051,7 +1051,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkSettleVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkSettleVaults',
         [vaultAddresses],
@@ -1072,7 +1072,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkRepayBonds(vaultAddresses, amounts, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkRepayBonds',
         [vaultAddresses, amounts],
@@ -1095,7 +1095,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkCollectFees(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkCollectFees',
         [vaultAddresses],
@@ -1113,7 +1113,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkCollectFees(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkCollectFees',
         [vaultAddresses],
@@ -1132,7 +1132,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkProcessWithdrawalQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkProcessWithdrawalQueues',
         [vaultAddresses, maxProcessCount],
@@ -1151,7 +1151,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkProcessWithdrawalQueues(vaultAddresses, maxProcessCount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkProcessWithdrawalQueues',
         [vaultAddresses, maxProcessCount],
@@ -1169,7 +1169,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkRolloverVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkRolloverVaults',
         [vaultAddresses],
@@ -1187,7 +1187,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkRolloverVaults(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkRolloverVaults',
         [vaultAddresses],
@@ -1209,7 +1209,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsSubmitDispute(vaultAddress, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSubmitDispute',
         [vaultAddress],
@@ -1229,7 +1229,7 @@ export default class CegaEvmSDKV2 {
     const overrideDateInSeconds = Math.floor(overrideDateTime.getTime() / 1000);
     return cegaEntry.fcnSubmitDispute(vaultAddress, barrierIndex, overrideDateInSeconds, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSubmitDispute',
         [vaultAddress, barrierIndex, overrideDateInSeconds],
@@ -1248,7 +1248,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsProcessTradeDispute(vaultAddress, newPrice, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsProcessTradeDispute',
         [vaultAddress, newPrice],
@@ -1275,7 +1275,7 @@ export default class CegaEvmSDKV2 {
       newPrice,
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           cegaEntry,
           'fcnProcessTradeDispute',
           [vaultAddress, barrierIndex, overrideDateInSeconds, newPrice],
@@ -1331,7 +1331,7 @@ export default class CegaEvmSDKV2 {
       },
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           cegaEntry,
           'dcsCreateVault',
           [productId, { tokenName, tokenSymbol, yieldFeeBps, managementFeeBps }],
@@ -1362,7 +1362,7 @@ export default class CegaEvmSDKV2 {
       },
       {
         ...(await this._gasStation.getGasOraclePrices()),
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           cegaEntry,
           'fcnCreateVault',
           [productId, { tokenName, tokenSymbol, yieldFeeBps, managementFeeBps }],
@@ -1383,7 +1383,7 @@ export default class CegaEvmSDKV2 {
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetMaxUnderlyingAmount(maxUnderlyingAmount, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetMaxUnderlyingAmount',
         [maxUnderlyingAmount, productId],
@@ -1402,7 +1402,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetMaxUnderlyingAmount(productId, maxUnderlyingAmount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetMaxUnderlyingAmount',
         [productId, maxUnderlyingAmount],
@@ -1422,7 +1422,7 @@ export default class CegaEvmSDKV2 {
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetMinDepositAmount(minDepositAmount, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetMinDepositAmount',
         [minDepositAmount, productId],
@@ -1441,7 +1441,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetMinDepositAmount(productId, minDepositAmount, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetMinDepositAmount',
         [productId, minDepositAmount],
@@ -1460,7 +1460,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsSetDaysToStartLateFees(productId, daysToStartLateFees, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetDaysToStartLateFees',
         [productId, daysToStartLateFees],
@@ -1480,7 +1480,7 @@ export default class CegaEvmSDKV2 {
     // TODO: asked SC to reorder these params to be consistent with FCN
     return cegaEntry.dcsSetLateFeeBps(lateFeeBps, productId, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetLateFeeBps',
         [lateFeeBps, productId],
@@ -1499,7 +1499,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetLateFeeBps(productId, lateFeeBps, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetLateFeeBps',
         [productId, lateFeeBps],
@@ -1518,7 +1518,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsSetDaysToStartAuctionDefault(productId, daysToStartAuctionDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetDaysToStartAuctionDefault',
         [productId, daysToStartAuctionDefault],
@@ -1537,7 +1537,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetDaysToStartAuctionDefault(productId, daysToStartAuctionDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetDaysToStartAuctionDefault',
         [productId, daysToStartAuctionDefault],
@@ -1556,7 +1556,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsSetDaysToStartSettlementDefault(productId, daysToStartSettlementDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetDaysToStartSettlementDefault',
         [productId, daysToStartSettlementDefault],
@@ -1575,7 +1575,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetDaysToStartSettlementDefault(productId, daysToStartSettlementDefault, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetDaysToStartSettlementDefault',
         [productId, daysToStartSettlementDefault],
@@ -1594,7 +1594,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsSetDisputeGraceDelayInHours(productId, disputeGraceDelayInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetDisputeGraceDelayInHours',
         [productId, disputeGraceDelayInHours],
@@ -1613,7 +1613,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetDisputeGraceDelayInHours(productId, disputeGraceDelayInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetDisputeGraceDelayInHours',
         [productId, disputeGraceDelayInHours],
@@ -1632,7 +1632,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsSetDisputePeriodInHours(productId, disputePeriodInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsSetDisputePeriodInHours',
         [productId, disputePeriodInHours],
@@ -1651,7 +1651,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnSetDisputePeriodInHours(productId, disputePeriodInHours, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnSetDisputePeriodInHours',
         [productId, disputePeriodInHours],
@@ -1674,7 +1674,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkCheckBarriers(vaultAddresses, maxObservations, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkCheckBarriers',
         [vaultAddresses, maxObservations],
@@ -1692,7 +1692,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkCheckAuctionDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkCheckAuctionDefault',
         [vaultAddresses],
@@ -1710,7 +1710,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkCheckAuctionDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkCheckAuctionDefault',
         [vaultAddresses],
@@ -1728,7 +1728,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkCheckSettlementDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkCheckSettlementDefault',
         [vaultAddresses],
@@ -1746,7 +1746,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkCheckSettlementDefault(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkCheckSettlementDefault',
         [vaultAddresses],
@@ -1764,7 +1764,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.dcsBulkCheckTradesExpiry(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'dcsBulkCheckTradesExpiry',
         [vaultAddresses],
@@ -1782,7 +1782,7 @@ export default class CegaEvmSDKV2 {
 
     return cegaEntry.fcnBulkCheckTradesExpiry(vaultAddresses, {
       ...(await this._gasStation.getGasOraclePrices()),
-      ...(await getEstimatedGasLimitWithOverrides(
+      ...(await getOverridesWithEstimatedGasLimit(
         cegaEntry,
         'fcnBulkCheckTradesExpiry',
         [vaultAddresses],
@@ -1831,7 +1831,7 @@ export default class CegaEvmSDKV2 {
       {
         value: fee,
         ...(await this._gasStation.getGasOraclePrices()),
-        ...(await getEstimatedGasLimitWithOverrides(
+        ...(await getOverridesWithEstimatedGasLimit(
           pythAdapter,
           'updateAssetPrices',
           [Math.floor(timestamp.getTime() / 1000), assetAddresses, updates],

--- a/src/testScripts/sdkV2-scripts.ts
+++ b/src/testScripts/sdkV2-scripts.ts
@@ -58,14 +58,14 @@ const CURRENT_NETWORK: Network = Network.arbitrum;
 function loadSettings(network: Network) {
   const config = CONFIGS[network];
   const provider = new ethers.providers.JsonRpcProvider(config.RPC_URL);
-  const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.programAdminPk, provider);
+  // const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.programAdminPk, provider);
 
   const sdk = new CegaEvmSDKV2(
     config.addressManager,
     config.treasuryAddress,
     config.gasStation,
     provider,
-    userSigner,
+    // userSigner,
   );
   return { sdk };
 }
@@ -287,7 +287,7 @@ async function main() {
   // await getQueues(Network.ethereum);
   // await addDeposits(CURRENT_NETWORK);
   // await bulkActions(CURRENT_NETWORK);
+  // await depositUsingESTGasLimit();
 }
 
 main();
-depositUsingESTGasLimit();

--- a/src/testScripts/sdkV2-scripts.ts
+++ b/src/testScripts/sdkV2-scripts.ts
@@ -58,14 +58,14 @@ const CURRENT_NETWORK: Network = Network.arbitrum;
 function loadSettings(network: Network) {
   const config = CONFIGS[network];
   const provider = new ethers.providers.JsonRpcProvider(config.RPC_URL);
-  // const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.userPk, provider);
+  const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.programAdminPk, provider);
 
   const sdk = new CegaEvmSDKV2(
     config.addressManager,
     config.treasuryAddress,
     config.gasStation,
     provider,
-    // userSigner,
+    userSigner,
   );
   return { sdk };
 }
@@ -123,6 +123,18 @@ async function addDeposits(network: Network) {
   // console.log('increaseAllowance stETH: ', txReceipt.transactionHash);
   // txResponse = await sdk.dcsAddToDepositQueue(stethProductId, amount, config.stEth);
   // console.log('deposit stETH: ', txResponse.hash);
+}
+
+async function depositUsingESTGasLimit() {
+  const { sdk } = loadSettings(CURRENT_NETWORK);
+
+  const amount = ethers.utils.parseUnits('0.0004', 18);
+  const txResponse = await sdk.addToDepositQueue(
+    67,
+    amount,
+    '0x0000000000000000000000000000000000000000',
+  );
+  console.log('TxResponse:', txResponse);
 }
 
 async function bulkActions(network: Network) {
@@ -278,3 +290,4 @@ async function main() {
 }
 
 main();
+depositUsingESTGasLimit();

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,7 @@ export interface SDKCache {
 }
 
 export interface TxOverrides {
-  gasLimit?: number;
+  gasLimit?: ethers.BigNumber | number;
   gasPrice?: number;
   maxFeePerGas?: number;
   maxPriorityFeePerGas?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,7 +180,7 @@ export interface SDKCache {
 }
 
 export interface TxOverrides {
-  gasLimit?: ethers.BigNumber | number;
+  gasLimit?: ethers.BigNumberish;
   gasPrice?: number;
   maxFeePerGas?: number;
   maxPriorityFeePerGas?: number;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,19 +40,30 @@ export async function getEstimatedGasLimit(
   methodName: string,
   args: any[],
   signer?: ethers.Signer,
-  bufferPercentage = 20,
+  bufferPercentage = 50,
 ): Promise<number> {
-  const sender = signer ? await signer.getAddress() : null;
+  const from = signer ? await signer.getAddress() : null;
+  console.log('from', from);
+  console.log('args', args);
   try {
-    const gasLimit = await contract.estimateGas[methodName](...args, {
-      from: sender,
-    });
+    const gasLimit = await contract.estimateGas[methodName](...args);
 
     // Add buffer to the estimated gas limit
     const buffer = gasLimit.mul(bufferPercentage).div(100);
-
+    console.log(
+      `Estimated gas limit for ${methodName} with args:`,
+      args,
+      'is',
+      gasLimit.add(buffer).toNumber(),
+    );
     return gasLimit.add(buffer).toNumber();
   } catch (error) {
+    console.error(
+      `Failed to estimate gas limit for ${methodName} with args:`,
+      args,
+      'Error:',
+      error,
+    );
     return 0;
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,7 +42,7 @@ export async function getEstimatedGasLimitWithOverrides(
   args: any[],
   signer?: ethers.Signer,
   overrides: TxOverrides = {},
-  bufferPercentage = 50,
+  bufferPercentage = 20,
 ): Promise<TxOverrides> {
   const { gasLimit: customGasLimit, ...rest } = overrides;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ export function getEvmContractType(productName: string): EvmContractType {
  * And then it will return the overrides object with the estimated/ manual gas limit.
  * @returns {number} The estimated gas limit
  */
-export async function getEstimatedGasLimitWithOverrides(
+export async function getOverridesWithEstimatedGasLimit(
   contract: ethers.Contract,
   methodName: string,
   args: any[],


### PR DESCRIPTION
### Overview
This PR is the fix of #69. The proposed changes are:

1. Fetching dynamic gas limits for every contract call at first,
2. If this fails, we will use manual gas limits set by the FE.

Previously we would have overridden the dynamic one if any manual gas limits were mentioned in the `overrides`.

### TO DO:
- [x] Tests need to be done before merging it.