### PR TITLE
Removed util function from import that's causing build error

### DIFF
--- a/src/testScripts/sdkV1-getters.ts
+++ b/src/testScripts/sdkV1-getters.ts
@@ -5,8 +5,6 @@ import * as dotenv from 'dotenv';
 
 import { ethers } from 'ethers';
 import { CegaEvmSDK, EthereumAlchemyGasStation, ArbitrumAlchemyGasStation, types } from '..';
-import CegaStateAbi from '../abi/LOVProduct.json';
-import { getEstimatedGasLimit } from '../utils';
 
 dotenv.config();
 


### PR DESCRIPTION
A quick PR to fix the build error. The `getEstimatedGasLimit` had been renamed in the previous PR (#70) but one of the test scripts was still importing it. That's why we had a build error for the previous PR. That version has not been published to npm yet that's why the version on `package.json` hasn't been upgraded. Merging this PR will build & publish the changes of #70.