### PR TITLE
[CEG-1723] Resolved issue of `sfnBulkStartTrades` not having asset amount as a param

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.1.9",
+  "version": "1.2.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -1988,6 +1988,7 @@ export default class CegaEvmSDKV2 {
 
   async sfnBulkStartTrades(
     vaultAddresses: EvmAddress[],
+    nativeAssetTransferSummedAmount?: ethers.BigNumber,
     overrides: TxOverrides = {},
   ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
@@ -2001,6 +2002,7 @@ export default class CegaEvmSDKV2 {
         this._signer,
         overrides,
       )),
+      value: nativeAssetTransferSummedAmount ?? 0,
     });
   }
 


### PR DESCRIPTION
This PR will fix the issue of `sfnBulkStartTrades` in the sdkV2, not taking `nativeAssetTransferSummedAmount` as a parameter.