### PR TITLE
Increasing gaslimit buffer for addToDeposit queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -556,6 +556,7 @@ export default class CegaEvmSDKV2 {
         [productId, amount, await this._signer.getAddress()],
         this._signer,
         overrides,
+        50,
       )),
       value: asset === ethers.constants.AddressZero ? amount : 0,
     });


### PR DESCRIPTION
Some arb transactions are running out of gas. Until a better fix is in place, we can increase the buffer