### PR TITLE
added a temporary fix for `sfnCalculateVaultSettlementAmount`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -2184,9 +2184,10 @@ export default class CegaEvmSDKV2 {
     return cegaEntry.sfnCalculateVaultFinalPayoff(vaultAddress);
   }
 
-  async sfnCalculateVaultSettlementAmount(vaultAddress: EvmAddress): Promise<ethers.BigNumber> {
-    const cegaEntry = await this.loadCegaEntry();
-    return cegaEntry.sfnCalculateVaultSettlementAmount(vaultAddress);
+  static sfnCalculateVaultSettlementAmount(vaultAddress: EvmAddress): ethers.BigNumberish {
+    // The SC method is returning a wrong value for this method, where it should have been return 0.
+    // This is a temporary fix until the SC is fixed.
+    return 0;
   }
 
   async sfnCreateVault(


### PR DESCRIPTION
The particular function returns a non-zero amount during settlement, whereas for SFN vaults since the MM returns the notional they should receive nothing. I believe, this is a temporary fix and should be reverted once the SC is fixed. We haven't received any response from the SC team that's why this fix has been made.