### PR TITLE
bumped up dynamic gas limit buffer for DCS deposits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -677,7 +677,7 @@ export default class CegaEvmSDKV2 {
           [productId, amount, await this._signer.getAddress(), rotationStrategyParams],
           this._signer,
           overrides,
-          50,
+          80,
         )),
         value: asset === ethers.constants.AddressZero ? amount : 0,
       },

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -817,6 +817,7 @@ export default class CegaEvmSDKV2 {
         [vaultAddress, sharesAmount, nextProductId],
         this._signer,
         overrides,
+        50,
       )),
     });
   }


### PR DESCRIPTION
Due to some recent errors, our users are facing due to gas limits on Arbitrum, the buffer for the dynamic gas limit is being increased to 80% for the `dcsAddToDepositQueueAndSetRotationStrategies` function.