### PR TITLE
Added type updates and introduced TxOverrides as a parameter for fill & cancel order functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -5,6 +5,7 @@ import {
   FillOrderResponse,
   GetOrderDataResponse,
   LpCegaOfframpOrder,
+  LpCegaOfframpOrderStringified,
   OracleDataSource,
   SFNEndAuctionParam,
   SFNEndAuctionParamForContract,
@@ -442,7 +443,7 @@ export default class CegaEvmSDKV2 {
     return cegaEntry.hashOrder(order);
   }
 
-  async getSignatureForOfframpOrder(order: LpCegaOfframpOrder): Promise<string> {
+  async getSignatureForOfframpOrder(order: LpCegaOfframpOrderStringified): Promise<string> {
     const signer = this._signer;
 
     if (!signer) {
@@ -462,6 +463,7 @@ export default class CegaEvmSDKV2 {
     makerSig,
     order,
     swapMakingAmount,
+    overrides = {},
   }: FillOrderParams): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
     return cegaEntry.fillOrder(order, makerSig, swapMakingAmount, {
@@ -471,11 +473,15 @@ export default class CegaEvmSDKV2 {
         'fillOrder',
         [order, makerSig, swapMakingAmount],
         this._signer,
+        overrides,
       )),
     });
   }
 
-  async cancelOrder(orderHash: string): Promise<ethers.providers.TransactionResponse> {
+  async cancelOrder(
+    orderHash: string,
+    overrides: TxOverrides = {},
+  ): Promise<ethers.providers.TransactionResponse> {
     const cegaEntry = await this.loadCegaEntry();
     return cegaEntry.cancelOrder(orderHash, {
       ...(await this._gasStation.getGasOraclePrices()),
@@ -484,6 +490,7 @@ export default class CegaEvmSDKV2 {
         'cancelOrder',
         [orderHash],
         this._signer,
+        overrides,
       )),
     });
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,10 +221,22 @@ export type LpCegaOfframpOrder = {
   makerTraits: ethers.BigNumber;
 };
 
+export type LpCegaOfframpOrderStringified = {
+  salt: string;
+  makingAmount: string;
+  takingAmount: string;
+  maker: EvmAddress;
+  makerAsset: EvmAddress;
+  takerAsset: EvmAddress;
+  expiry: string;
+  makerTraits: string;
+};
+
 export type FillOrderParams = {
   makerSig: string;
   order: LpCegaOfframpOrder;
   swapMakingAmount: ethers.BigNumber;
+  overrides: TxOverrides;
 };
 
 export type FillOrderResponse = {


### PR DESCRIPTION
This PR includes the following updates:
1. Added `TxOverrides` as an optional parameter to the `fillOrder` and `cancelOrder` functions.
2. Updated the type of the order in the `getSignatureForOfframpOrder` function. Since the backend requires stringified values of the order object, the `BigNumber` values were converted to strings to ensure consistency when generating the signature with the same object.