### PR TITLE
Resolved an issue with the fillOrder during ETH swap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cega-fi/cega-sdk-evm",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/src/sdkV2.ts
+++ b/src/sdkV2.ts
@@ -2,7 +2,6 @@ import { BigNumberish, ethers } from 'ethers';
 import {
   EvmAddress,
   FillOrderParams,
-  FillOrderResponse,
   GetOrderDataResponse,
   LpCegaOfframpOrder,
   LpCegaOfframpOrderStringified,
@@ -475,6 +474,7 @@ export default class CegaEvmSDKV2 {
         this._signer,
         overrides,
       )),
+      value: order.takerAsset === ethers.constants.AddressZero ? order.takingAmount : 0,
     });
   }
 

--- a/src/testScripts/sdkV2-scripts.ts
+++ b/src/testScripts/sdkV2-scripts.ts
@@ -293,9 +293,9 @@ async function fillOrder() {
   };
   const txResponse = await sdk.fillOrder(order);
   console.log('TxResponse:', txResponse);
-  txResponse.wait();
+  await txResponse.wait();
   console.log('Order Filled', order);
-  console.log('TxHash:', txResponse);
+  console.log('TxHash:', txResponse.hash);
 }
 
 async function main() {

--- a/src/testScripts/sdkV2-scripts.ts
+++ b/src/testScripts/sdkV2-scripts.ts
@@ -3,7 +3,7 @@
 import * as dotenv from 'dotenv';
 import fs from 'fs';
 
-import { ethers } from 'ethers';
+import { BigNumber, ethers } from 'ethers';
 import { CegaEvmSDKV2, EthereumAlchemyGasStation, types, GasStation } from '..';
 import { EvmAddress } from '../types';
 
@@ -58,14 +58,14 @@ const CURRENT_NETWORK: Network = Network.arbitrum;
 function loadSettings(network: Network) {
   const config = CONFIGS[network];
   const provider = new ethers.providers.JsonRpcProvider(config.RPC_URL);
-  // const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.programAdminPk, provider);
+  const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.programAdminPk, provider);
 
   const sdk = new CegaEvmSDKV2(
     config.addressManager,
     config.treasuryAddress,
     config.gasStation,
     provider,
-    // userSigner,
+    userSigner,
   );
   return { sdk };
 }
@@ -275,6 +275,29 @@ async function getVaults(network: Network, vaultAddresses: EvmAddress[]) {
   }
 }
 
+async function fillOrder() {
+  const { sdk } = loadSettings(CURRENT_NETWORK);
+  const order = {
+    swapMakingAmount: BigNumber.from('500000000000000'),
+    order: {
+      salt: '888',
+      makingAmount: '500000000000000',
+      takingAmount: '396400000000000',
+      maker: '' as EvmAddress, // add maker address
+      makerAsset: '' as EvmAddress, // add maker asset
+      takerAsset: '0x0000000000000000000000000000000000000000' as EvmAddress,
+      expiry: '1726942743',
+      makerTraits: '0',
+    },
+    makerSig: '', // add signature
+  };
+  const txResponse = await sdk.fillOrder(order);
+  console.log('TxResponse:', txResponse);
+  txResponse.wait();
+  console.log('Order Filled', order);
+  console.log('TxHash:', txResponse);
+}
+
 async function main() {
   // const { columns: productColumns, data: productData } = await getProducts(
   //   Network.ethereum,
@@ -288,6 +311,7 @@ async function main() {
   // await addDeposits(CURRENT_NETWORK);
   // await bulkActions(CURRENT_NETWORK);
   // await depositUsingESTGasLimit();
+  // await fillOrder();
 }
 
 main();

--- a/src/testScripts/sdkV2-scripts.ts
+++ b/src/testScripts/sdkV2-scripts.ts
@@ -58,14 +58,14 @@ const CURRENT_NETWORK: Network = Network.arbitrum;
 function loadSettings(network: Network) {
   const config = CONFIGS[network];
   const provider = new ethers.providers.JsonRpcProvider(config.RPC_URL);
-  const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.programAdminPk, provider);
+  // const userSigner = new ethers.Wallet(ADMIN_ACCOUNTS.programAdminPk, provider);
 
   const sdk = new CegaEvmSDKV2(
     config.addressManager,
     config.treasuryAddress,
     config.gasStation,
     provider,
-    userSigner,
+    // userSigner,
   );
   return { sdk };
 }


### PR DESCRIPTION
For the `fillOrder` function, there needs to be a `value` to be passed along with other parameters if we want to swap ETH. Did a test with an order and [the transaction](https://arbiscan.io/tx/0xa62d1ffa345b87b1029cfb5db1ef1b399e76f4e24cfebad8c7d5342955bc900c) went through. Kept the changes on the test script for future use.